### PR TITLE
feat: tweak `typed_uid` macro

### DIFF
--- a/apps/foundation/uid/src/encoding.rs
+++ b/apps/foundation/uid/src/encoding.rs
@@ -65,9 +65,8 @@ mod tests {
     use crate::typed_uid;
 
     typed_uid! {
-        serde::Serialize, serde::Deserialize;
-
-        AccountUid,
+        Derive(serde::Serialize, serde::Deserialize)
+        Define(AccountUid)
     }
 
     #[test]

--- a/apps/foundation/uid/src/lib.rs
+++ b/apps/foundation/uid/src/lib.rs
@@ -50,11 +50,39 @@ macro_rules! typed_uid {
         typed_uid!(@internal [$($derive),*] $($rest),+);
     };
 
-    ($($derive:path),+ ; $($name:ident),+ $(,)?) => {
+    (Derive($($derive:path),+) $(,)? Define($($name:ident),+) $(,)?) => {
         typed_uid!(@internal [$($derive),+] $($name),+);
     };
 
-    ($($name:ident),+ $(,)?) => {
+    (Define($($name:ident),+) $(,)?) => {
         typed_uid!(@internal [] $($name),+);
     };
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashSet;
+    use std::hash::Hash;
+
+    use uuid::Uuid;
+
+    typed_uid! {
+        Define(AccountUid)
+    }
+
+    typed_uid! {
+        Derive(Hash, PartialEq, Eq), Define(HashUid)
+    }
+
+    #[test]
+    fn can_define_basic_uids() {
+        let _ = AccountUid::new();
+    }
+
+    #[test]
+    fn can_add_custom_derives() {
+        let mut items: HashSet<HashUid> = HashSet::new();
+
+        items.insert(HashUid::new());
+    }
 }


### PR DESCRIPTION
At the moment, the invocations of `typed_uid` make it a little difficult to see where to put things. It might be easier to add some function-like keywords here to distinguish between the traits we are deriving and the UIDs we are defining.

This change:
* Makes those API changes
