### PR TITLE
feat: add telemetry to `tag-updater`

### DIFF
--- a/apps/Cargo.lock
+++ b/apps/Cargo.lock
@@ -1092,7 +1092,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "778e2ac28f6c47af28e4907f13ffd1e1ddbd400980a9abd7c8df189bf578a5ad"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1170,7 +1170,6 @@ dependencies = [
 name = "foundation-logging"
 version = "0.1.0"
 dependencies = [
- "color-eyre",
  "tracing",
  "tracing-error",
  "tracing-subscriber",
@@ -1881,7 +1880,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07033963ba89ebaf1584d767badaa2e8fcec21aedea6b8c0346d487d49c28667"
 dependencies = [
  "cfg-if",
- "windows-targets 0.52.6",
+ "windows-targets 0.53.3",
 ]
 
 [[package]]
@@ -1949,11 +1948,11 @@ dependencies = [
 
 [[package]]
 name = "matchers"
-version = "0.1.0"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8263075bb86c5a1b1427b5ae862e8889656f126e9f77c484496e8b47cf5c5558"
+checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
 dependencies = [
- "regex-automata 0.1.10",
+ "regex-automata",
 ]
 
 [[package]]
@@ -2022,12 +2021,11 @@ dependencies = [
 
 [[package]]
 name = "nu-ansi-term"
-version = "0.46.0"
+version = "0.50.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77a8165726e8236064dbb45459242600304b42a5ea24ee2948e18e023bf7ba84"
+checksum = "d4a28e057d01f97e61255210fcff094d74ed0466038633e95017f5beb68e4399"
 dependencies = [
- "overload",
- "winapi",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2170,12 +2168,6 @@ name = "outref"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a80800c0488c3a21695ea981a54918fbb37abf04f4d0720c453632255e2ff0e"
-
-[[package]]
-name = "overload"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
 name = "owo-colors"
@@ -2419,17 +2411,8 @@ checksum = "b544ef1b4eac5dc2db33ea63606ae9ffcfac26c1416a2806ae0bf5f56b201191"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-automata 0.4.9",
- "regex-syntax 0.8.5",
-]
-
-[[package]]
-name = "regex-automata"
-version = "0.1.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
-dependencies = [
- "regex-syntax 0.6.29",
+ "regex-automata",
+ "regex-syntax",
 ]
 
 [[package]]
@@ -2440,7 +2423,7 @@ checksum = "809e8dc61f6de73b46c85f4c96486310fe304c434cfa43669d7b40f711150908"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax 0.8.5",
+ "regex-syntax",
 ]
 
 [[package]]
@@ -2448,12 +2431,6 @@ name = "regex-lite"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "53a49587ad06b26609c52e423de037e7f57f20d53535d66e08c695f347df952a"
-
-[[package]]
-name = "regex-syntax"
-version = "0.6.29"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
 name = "regex-syntax"
@@ -3000,11 +2977,13 @@ dependencies = [
  "color-eyre",
  "foundation-configuration",
  "foundation-logging",
+ "foundation-telemetry",
  "git2",
  "pico-args",
  "serde",
  "tokio",
  "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -3291,14 +3270,14 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.3.19"
+version = "0.3.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8189decb5ac0fa7bc8b96b7cb9b2701d60d48805aca84a238004d665fcc4008"
+checksum = "2054a14f5307d601f88daf0553e1cbf472acc4f2c51afab632431cdcd72124d5"
 dependencies = [
  "matchers",
  "nu-ansi-term",
  "once_cell",
- "regex",
+ "regex-automata",
  "sharded-slab",
  "smallvec",
  "thread_local",
@@ -3528,28 +3507,6 @@ dependencies = [
  "once_cell",
  "rustix",
 ]
-
-[[package]]
-name = "winapi"
-version = "0.3.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
-dependencies = [
- "winapi-i686-pc-windows-gnu",
- "winapi-x86_64-pc-windows-gnu",
-]
-
-[[package]]
-name = "winapi-i686-pc-windows-gnu"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
-
-[[package]]
-name = "winapi-x86_64-pc-windows-gnu"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-link"

--- a/apps/foundation/logging/Cargo.toml
+++ b/apps/foundation/logging/Cargo.toml
@@ -4,7 +4,6 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
-color-eyre = { version = "0.6.5", default-features = false }
 tracing = "0.1.41"
 tracing-error = "0.2.1"
 tracing-subscriber = { version = "0.3.19", features = ["env-filter"] }

--- a/apps/foundation/logging/src/lib.rs
+++ b/apps/foundation/logging/src/lib.rs
@@ -5,14 +5,14 @@ use tracing_subscriber::layer::{Layered, SubscriberExt};
 use tracing_subscriber::util::SubscriberInitExt;
 use tracing_subscriber::{EnvFilter, Registry};
 
+type RegistryLayer = Layered<Layer<Registry>, Registry>;
+
 pub fn install_default_registry() {
     get_default_registry().init();
 }
 
-pub fn get_default_registry() -> Layered<
-    EnvFilter,
-    Layered<ErrorLayer<Layered<Layer<Registry>, Registry>>, Layered<Layer<Registry>, Registry>>,
-> {
+pub fn get_default_registry()
+-> Layered<EnvFilter, Layered<ErrorLayer<RegistryLayer>, RegistryLayer>> {
     let fmt_layer = tracing_subscriber::fmt::layer();
     let error_layer = ErrorLayer::default();
     let env_filter_layer = EnvFilter::builder()

--- a/apps/foundation/logging/src/lib.rs
+++ b/apps/foundation/logging/src/lib.rs
@@ -1,22 +1,27 @@
-use color_eyre::eyre::Result;
 use tracing::level_filters::LevelFilter;
 use tracing_error::ErrorLayer;
-use tracing_subscriber::EnvFilter;
-use tracing_subscriber::layer::SubscriberExt;
+use tracing_subscriber::fmt::Layer;
+use tracing_subscriber::layer::{Layered, SubscriberExt};
 use tracing_subscriber::util::SubscriberInitExt;
+use tracing_subscriber::{EnvFilter, Registry};
 
-pub fn install_default_registry() -> Result<()> {
+pub fn install_default_registry() {
+    get_default_registry().init();
+}
+
+pub fn get_default_registry() -> Layered<
+    EnvFilter,
+    Layered<ErrorLayer<Layered<Layer<Registry>, Registry>>, Layered<Layer<Registry>, Registry>>,
+> {
     let fmt_layer = tracing_subscriber::fmt::layer();
     let error_layer = ErrorLayer::default();
     let env_filter_layer = EnvFilter::builder()
         .with_default_directive(LevelFilter::INFO.into())
-        .from_env()?;
+        .from_env()
+        .unwrap_or_else(|_| EnvFilter::new("info"));
 
     tracing_subscriber::registry()
         .with(fmt_layer)
         .with(error_layer)
         .with(env_filter_layer)
-        .init();
-
-    Ok(())
 }

--- a/apps/tag-updater/Cargo.toml
+++ b/apps/tag-updater/Cargo.toml
@@ -11,8 +11,10 @@ axum-extra = { version = "0.10.1", features = ["typed-header"] }
 color-eyre = { version = "0.6.5", default-features = false }
 foundation-configuration = { path = "../foundation/configuration", features = ["external-bytes"] }
 foundation-logging = { path = "../foundation/logging", version = "0.1.0" }
+foundation-telemetry = { version = "0.1.0", path = "../foundation/telemetry" }
 git2 = { version = "0.20.2", default-features = false, features = ["ssh"] }
 pico-args = "0.5.0"
 serde = { version = "1.0.219", features = ["derive"] }
 tokio = { version = "1.47.1", features = ["macros", "rt-multi-thread"] }
 tracing = "0.1.41"
+tracing-subscriber = "0.3.20"

--- a/apps/tag-updater/src/config.rs
+++ b/apps/tag-updater/src/config.rs
@@ -9,4 +9,11 @@ pub struct Config {
     pub port: u16,
     pub passphrase: Secret<String>,
     pub private_key: ExternalBytes,
+    pub telemetry: Option<TelemetryConfig>,
+}
+
+#[derive(Deserialize)]
+pub struct TelemetryConfig {
+    pub enabled: bool,
+    pub endpoint: String,
 }

--- a/apps/utils/application-bootstrap/src/main.rs
+++ b/apps/utils/application-bootstrap/src/main.rs
@@ -10,7 +10,7 @@ use crate::args::Args;
 
 fn setup() -> Result<()> {
     color_eyre::install()?;
-    foundation_logging::install_default_registry()?;
+    foundation_logging::install_default_registry();
 
     Ok(())
 }


### PR DESCRIPTION
In order to have more things reporting to ClickStack, let's enable telemetry for `tag-updater` as well.

This change:
* Tweaks the logging implementation to allow getting the registry and adding things to it
* Adds it to `tag-updater` and tweaks the `tracing` usages
