### PR TITLE
feat: move `http-server` to `foundation`

### DIFF
--- a/apps/Cargo.lock
+++ b/apps/Cargo.lock
@@ -589,45 +589,11 @@ dependencies = [
 
 [[package]]
 name = "axum"
-version = "0.7.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edca88bc138befd0323b20752846e6587272d3b03b0343c8ea28a6f819e6e71f"
-dependencies = [
- "async-trait",
- "axum-core 0.4.5",
- "bytes",
- "futures-util",
- "http 1.3.1",
- "http-body 1.0.1",
- "http-body-util",
- "hyper 1.7.0",
- "hyper-util",
- "itoa",
- "matchit 0.7.3",
- "memchr",
- "mime",
- "percent-encoding",
- "pin-project-lite",
- "rustversion",
- "serde",
- "serde_json",
- "serde_path_to_error",
- "serde_urlencoded",
- "sync_wrapper",
- "tokio",
- "tower 0.5.2",
- "tower-layer",
- "tower-service",
- "tracing",
-]
-
-[[package]]
-name = "axum"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "021e862c184ae977658b36c4500f7feac3221ca5da43e3f25bd04ab6c79a29b5"
 dependencies = [
- "axum-core 0.5.2",
+ "axum-core",
  "bytes",
  "form_urlencoded",
  "futures-util",
@@ -637,7 +603,7 @@ dependencies = [
  "hyper 1.7.0",
  "hyper-util",
  "itoa",
- "matchit 0.8.4",
+ "matchit",
  "memchr",
  "mime",
  "percent-encoding",
@@ -650,27 +616,6 @@ dependencies = [
  "sync_wrapper",
  "tokio",
  "tower 0.5.2",
- "tower-layer",
- "tower-service",
- "tracing",
-]
-
-[[package]]
-name = "axum-core"
-version = "0.4.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09f2bd6146b97ae3359fa0cc6d6b376d9539582c7b4220f041a33ec24c226199"
-dependencies = [
- "async-trait",
- "bytes",
- "futures-util",
- "http 1.3.1",
- "http-body 1.0.1",
- "http-body-util",
- "mime",
- "pin-project-lite",
- "rustversion",
- "sync_wrapper",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -702,8 +647,8 @@ version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "45bf463831f5131b7d3c756525b305d40f1185b688565648a92e1392ca35713d"
 dependencies = [
- "axum 0.8.4",
- "axum-core 0.5.2",
+ "axum",
+ "axum-core",
  "bytes",
  "futures-util",
  "headers",
@@ -1275,6 +1220,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "encoding_rs"
+version = "0.8.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1372,6 +1326,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
+name = "foreign-types"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
+dependencies = [
+ "foreign-types-shared",
+]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
+
+[[package]]
 name = "form_urlencoded"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1390,6 +1359,18 @@ dependencies = [
  "serde",
  "serde_yaml",
  "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "foundation-http-server"
+version = "0.1.0"
+dependencies = [
+ "axum",
+ "reqwest",
+ "tokio",
+ "tower-http 0.6.6",
+ "tower-service",
  "tracing",
 ]
 
@@ -1917,6 +1898,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper-tls"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
+dependencies = [
+ "bytes",
+ "http-body-util",
+ "hyper 1.7.0",
+ "hyper-util",
+ "native-tls",
+ "tokio",
+ "tokio-native-tls",
+ "tower-service",
+]
+
+[[package]]
 name = "hyper-util"
 version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1935,9 +1932,11 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "socket2 0.6.0",
+ "system-configuration",
  "tokio",
  "tower-service",
  "tracing",
+ "windows-registry",
 ]
 
 [[package]]
@@ -2284,6 +2283,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
 
 [[package]]
+name = "linux-raw-sys"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd945864f07fe9f5371a27ad7b52a172b4b499999f1d97574c9fa68373937e12"
+
+[[package]]
 name = "litemap"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2335,12 +2340,6 @@ checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
 dependencies = [
  "regex-automata",
 ]
-
-[[package]]
-name = "matchit"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e7465ac9959cc2b1404e8e2367b43684a6d13790fe23056cc8c6c5a6b7bcb94"
 
 [[package]]
 name = "matchit"
@@ -2426,6 +2425,23 @@ dependencies = [
  "tagptr",
  "thiserror 1.0.69",
  "uuid",
+]
+
+[[package]]
+name = "native-tls"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87de3442987e9dbec73158d5c715e7ad9072fda936bb03d19d7fa10e00520f0e"
+dependencies = [
+ "libc",
+ "log",
+ "openssl",
+ "openssl-probe",
+ "openssl-sys",
+ "schannel",
+ "security-framework 2.11.1",
+ "security-framework-sys",
+ "tempfile",
 ]
 
 [[package]]
@@ -2520,6 +2536,32 @@ name = "once_cell_polyfill"
 version = "1.70.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4895175b425cb1f87721b59f0f286c2092bd4af812243672510e1ac53e2e0ad"
+
+[[package]]
+name = "openssl"
+version = "0.10.73"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8505734d46c8ab1e19a1dce3aef597ad87dcb4c37e7188231769bd6bd51cebf8"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "foreign-types",
+ "libc",
+ "once_cell",
+ "openssl-macros",
+ "openssl-sys",
+]
+
+[[package]]
+name = "openssl-macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.106",
+]
 
 [[package]]
 name = "openssl-probe"
@@ -3081,23 +3123,31 @@ checksum = "d429f34c8092b2d42c7c93cec323bb4adeb7c67698f70839adec842ec10c7ceb"
 dependencies = [
  "base64 0.22.1",
  "bytes",
+ "encoding_rs",
  "futures-channel",
  "futures-core",
  "futures-util",
+ "h2 0.4.12",
  "http 1.3.1",
  "http-body 1.0.1",
  "http-body-util",
  "hyper 1.7.0",
+ "hyper-rustls 0.27.7",
+ "hyper-tls",
  "hyper-util",
  "js-sys",
  "log",
+ "mime",
+ "native-tls",
  "percent-encoding",
  "pin-project-lite",
+ "rustls-pki-types",
  "serde",
  "serde_json",
  "serde_urlencoded",
  "sync_wrapper",
  "tokio",
+ "tokio-native-tls",
  "tower 0.5.2",
  "tower-http 0.6.6",
  "tower-service",
@@ -3182,8 +3232,21 @@ dependencies = [
  "bitflags",
  "errno",
  "libc",
- "linux-raw-sys",
+ "linux-raw-sys 0.4.15",
  "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "rustix"
+version = "1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11181fbabf243db407ef8df94a6ce0b2f9a733bd8be4ad02b4eda9602296cac8"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys 0.9.4",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3886,10 +3949,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "system-configuration"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c879d448e9d986b661742763247d3693ed13609438cf3d006f51f5368a5ba6b"
+dependencies = [
+ "bitflags",
+ "core-foundation 0.9.4",
+ "system-configuration-sys",
+]
+
+[[package]]
+name = "system-configuration-sys"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e1d1b10ced5ca923a1fcb8d03e96b8d3268065d724548c0211415ff6ac6bac4"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
 name = "tag-updater"
 version = "0.1.0"
 dependencies = [
- "axum 0.8.4",
+ "axum",
  "axum-extra",
  "color-eyre",
  "foundation-configuration",
@@ -3908,6 +3992,19 @@ name = "tagptr"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b2093cf4c8eb1e67749a6762251bc9cd836b6fc171623bd0a9d324d37af2417"
+
+[[package]]
+name = "tempfile"
+version = "3.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15b61f8f20e3a6f7e0649d825294eaf317edce30f82cf6026e7e4cb9222a7d1e"
+dependencies = [
+ "fastrand",
+ "getrandom 0.3.3",
+ "once_cell",
+ "rustix 1.0.8",
+ "windows-sys 0.52.0",
+]
 
 [[package]]
 name = "tera"
@@ -4039,11 +4136,12 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 name = "today"
 version = "0.1.0"
 dependencies = [
- "axum 0.7.9",
+ "axum",
  "chrono",
  "color-eyre",
  "dotenvy",
  "foundation-configuration",
+ "foundation-http-server",
  "foundation-logging",
  "foundation-telemetry",
  "foundation-uid",
@@ -4093,6 +4191,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.106",
+]
+
+[[package]]
+name = "tokio-native-tls"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
+dependencies = [
+ "native-tls",
+ "tokio",
 ]
 
 [[package]]
@@ -4229,6 +4337,7 @@ dependencies = [
  "tower 0.5.2",
  "tower-layer",
  "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -4687,7 +4796,7 @@ dependencies = [
  "either",
  "home",
  "once_cell",
- "rustix",
+ "rustix 0.38.44",
 ]
 
 [[package]]
@@ -4791,6 +4900,17 @@ checksum = "9150af68066c4c5c07ddc0ce30421554771e528bde427614c61038bc2c92c2b1"
 dependencies = [
  "windows-core",
  "windows-link",
+]
+
+[[package]]
+name = "windows-registry"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b8a9ed28765efc97bbc954883f4e6796c33a06546ebafacbabee9696967499e"
+dependencies = [
+ "windows-link",
+ "windows-result",
+ "windows-strings",
 ]
 
 [[package]]

--- a/apps/Cargo.toml
+++ b/apps/Cargo.toml
@@ -2,6 +2,7 @@
 resolver = "3"
 members = [
 	"foundation/configuration",
+	"foundation/http-server",
 	"foundation/logging",
 	"foundation/telemetry",
 	"foundation/uid",

--- a/apps/foundation/http-server/Cargo.toml
+++ b/apps/foundation/http-server/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "foundation-http-server"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]
+axum = "0.8.4"
+tokio = { version = "1.47.1", default-features = false, features = ["net"] }
+tower-http = { version = "0.6.6", features = ["trace"] }
+tower-service = "0.3.3"
+tracing = "0.1.41"
+
+[dev-dependencies]
+reqwest = "0.12.23"

--- a/apps/foundation/http-server/src/lib.rs
+++ b/apps/foundation/http-server/src/lib.rs
@@ -1,0 +1,177 @@
+use std::convert::Infallible;
+use std::io::Error;
+use std::ops::{Deref, DerefMut};
+use std::time::Duration;
+
+use axum::Router;
+use axum::body::Body;
+use axum::http::{Request, Response};
+use axum::response::IntoResponse;
+use axum::routing::MethodRouter;
+use tokio::net::TcpListener;
+use tower_http::trace::{DefaultMakeSpan, TraceLayer};
+use tower_service::Service;
+use tracing::{Level, Span};
+
+pub struct Server<S = ()> {
+    router: Router<S>,
+}
+
+impl<S> Server<S>
+where
+    S: Clone + Send + Sync + 'static,
+{
+    pub fn new() -> Self {
+        let router = Router::new();
+
+        Server { router }
+    }
+
+    pub fn route(self, path: &str, method_router: MethodRouter<S>) -> Self {
+        let router = self.router.route(path, method_router);
+
+        Server { router }
+    }
+
+    pub fn with_state<S2>(self, state: S) -> Server<S2> {
+        let router = self.router.with_state(state);
+
+        Server { router }
+    }
+
+    pub fn nest_service<T>(self, path: &str, service: T) -> Self
+    where
+        T: Service<Request<Body>, Error = Infallible> + Clone + Send + Sync + 'static,
+        T::Response: IntoResponse,
+        T::Future: Send + 'static,
+    {
+        let router = self.router.nest_service(path, service);
+
+        Server { router }
+    }
+}
+
+impl Server<()> {
+    pub async fn run(self, listener: TcpListener) -> Result<(), Error> {
+        let trace_layer = TraceLayer::new_for_http()
+            .make_span_with(DefaultMakeSpan::new().level(Level::INFO))
+            .on_request(|request: &Request<Body>, _span: &Span| {
+                tracing::info!(method = %request.method(), uri = %request.uri(), "received request");
+            })
+            .on_response(
+                |response: &Response<Body>, latency: Duration, _span: &Span| {
+                    tracing::info!(status = %response.status(), latency = ?latency, "sent response");
+                },
+            );
+
+        let router = self.router.layer(trace_layer);
+
+        axum::serve(listener, router).await?;
+
+        Ok(())
+    }
+}
+
+impl Default for Server {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl<S> Deref for Server<S> {
+    type Target = Router<S>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.router
+    }
+}
+
+impl<S> DerefMut for Server<S> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.router
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::net::{Ipv4Addr, SocketAddrV4};
+
+    use axum::extract::State;
+    use axum::routing::get;
+    use reqwest::Client;
+    use tokio::net::TcpListener;
+
+    use crate::Server;
+
+    type TestResult<T> = Result<T, Box<dyn std::error::Error + Send + Sync>>;
+
+    #[tokio::test]
+    async fn can_create_servers() {
+        let server: Server<()> = Server::new();
+
+        assert!(!server.router.has_routes());
+    }
+
+    #[tokio::test]
+    async fn can_add_routes_to_a_server() {
+        let server: Server<()> = Server::new().route("/", get(|| async { "Hello, World!" }));
+
+        assert!(server.router.has_routes());
+    }
+
+    #[tokio::test]
+    async fn can_run_a_server() -> TestResult<()> {
+        let server: Server<()> = Server::new().route("/", get(|| async { "Hello, World!" }));
+
+        let addr = SocketAddrV4::new(Ipv4Addr::LOCALHOST, 0);
+        let listener = TcpListener::bind(addr).await?;
+        let local_addr = listener.local_addr()?;
+
+        let task = tokio::spawn(async move {
+            if let Err(e) = server.run(listener).await {
+                eprintln!("Server error: {}", e);
+            }
+        });
+
+        // make a request to the server
+        let client = Client::new();
+        let response = client.get(format!("http://{}", local_addr)).send().await?;
+
+        assert!(response.status().is_success());
+
+        task.abort();
+
+        Ok(())
+    }
+
+    async fn stateful_handler(state: State<String>) -> String {
+        state.0.clone()
+    }
+
+    #[tokio::test]
+    async fn can_add_state_to_a_server() -> TestResult<()> {
+        let server: Server<()> = Server::new()
+            .route("/", get(stateful_handler))
+            .with_state("Hello, World!".to_string());
+
+        let addr = SocketAddrV4::new(Ipv4Addr::LOCALHOST, 0);
+        let listener = TcpListener::bind(addr).await?;
+        let local_addr = listener.local_addr()?;
+
+        let task = tokio::spawn(async move {
+            if let Err(e) = server.run(listener).await {
+                eprintln!("Server error: {}", e);
+            }
+        });
+
+        // make a request to the server
+        let client = Client::new();
+        let response = client.get(format!("http://{}", local_addr)).send().await?;
+        let body = response.text().await?;
+
+        assert_eq!(body, "Hello, World!");
+        task.abort();
+
+        Ok(())
+    }
+}

--- a/apps/today/Cargo.toml
+++ b/apps/today/Cargo.toml
@@ -4,11 +4,12 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-axum = "0.7.5"
+axum = "0.8.4"
 chrono = { version = "0.4.38", default-features = false, features = ["now"] }
 color-eyre = "0.6.3"
 dotenvy = "0.15.7"
 foundation-configuration = { version = "0.1.0", path = "../foundation/configuration" }
+foundation-http-server = { version = "0.1.0", path = "../foundation/http-server" }
 foundation-logging = { version = "0.1.0", path = "../foundation/logging" }
 foundation-telemetry = { version = "0.1.0", path = "../foundation/telemetry" }
 foundation-uid = { version = "0.1.0", path = "../foundation/uid" }

--- a/apps/today/local-config.yaml
+++ b/apps/today/local-config.yaml
@@ -2,6 +2,10 @@ server:
   host: 127.0.0.1
   port: 8000
 
+telemetry:
+  enabled: false
+  endpoint: "http://localhost:4318/v1/traces"
+
 database:
   host: localhost
   port: 5432

--- a/apps/today/src/main.rs
+++ b/apps/today/src/main.rs
@@ -6,13 +6,13 @@ use tokio::net::TcpListener;
 use tracing_subscriber::layer::SubscriberExt;
 use tracing_subscriber::util::SubscriberInitExt;
 
-use crate::router::IndexCache;
+use crate::server::IndexCache;
 
 mod args;
 mod config;
 mod error;
 mod persistence;
-mod router;
+mod server;
 mod templates;
 mod uid;
 
@@ -51,12 +51,12 @@ async fn main() -> Result<()> {
     let index_cache = IndexCache::new(32);
 
     let addr = SocketAddrV4::new(config.server.host, config.server.port);
-    let router = crate::router::build(template_engine, pool, index_cache);
+    let server = crate::server::build(template_engine, pool, index_cache);
     let listener = TcpListener::bind(addr).await?;
 
     tracing::info!(?addr, "listening for incoming requests");
 
-    axum::serve(listener, router).await?;
+    server.run(listener).await?;
 
     Ok(())
 }

--- a/apps/today/src/tests.rs
+++ b/apps/today/src/tests.rs
@@ -2,27 +2,27 @@ use axum::body::Body;
 use axum::http::header::{AsHeaderName, CONTENT_TYPE, LOCATION};
 use axum::http::{Method, Request, StatusCode};
 use axum::response::Response;
-use axum::Router;
+use foundation_http_server::Server;
 use http_body_util::BodyExt;
 use serde_test::{assert_ser_tokens, Token};
 use sqlx::PgPool;
 use tower::Service;
 
 use crate::persistence::Content;
-use crate::router::IndexCache;
+use crate::server::IndexCache;
 use crate::templates::TemplateEngine;
 
 const FORM_MIME_TYPE: &str = "application/x-www-form-urlencoded";
 
 type Result<T> = std::result::Result<T, Box<dyn std::error::Error>>;
 
-fn build_router(pool: PgPool) -> Result<Router> {
+fn build_server(pool: PgPool) -> Result<Server> {
     let template_engine = TemplateEngine::new()?;
     let index_cache = IndexCache::new(1);
 
-    let router = crate::router::build(template_engine, pool, index_cache);
+    let server = crate::server::build(template_engine, pool, index_cache);
 
-    Ok(router)
+    Ok(server)
 }
 
 async fn read_full_body(response: Response) -> Result<String> {
@@ -38,12 +38,12 @@ fn get_response_header<'a, K: AsHeaderName>(response: &'a Response, header: K) -
 
 #[sqlx::test]
 async fn invalid_requests_get_404s(pool: PgPool) -> Result<()> {
-    let mut router = build_router(pool)?;
+    let mut server = build_server(pool)?;
     let request = Request::builder()
         .uri("/unknown-path")
         .body(Body::empty())?;
 
-    let response = router.call(request).await?;
+    let response = server.call(request).await?;
     let status = response.status();
 
     assert_eq!(status, StatusCode::NOT_FOUND);
@@ -53,7 +53,7 @@ async fn invalid_requests_get_404s(pool: PgPool) -> Result<()> {
 
 #[sqlx::test]
 async fn can_add_items(pool: PgPool) -> Result<()> {
-    let mut router = build_router(pool)?;
+    let mut server = build_server(pool)?;
 
     let request = Request::builder()
         .method(Method::POST)
@@ -61,7 +61,7 @@ async fn can_add_items(pool: PgPool) -> Result<()> {
         .header(CONTENT_TYPE, FORM_MIME_TYPE)
         .body(Body::from("content=Task"))?;
 
-    let response = router.call(request).await?;
+    let response = server.call(request).await?;
 
     // Get redirected to the index page
     assert_eq!(response.status(), StatusCode::FOUND);
@@ -72,7 +72,7 @@ async fn can_add_items(pool: PgPool) -> Result<()> {
         .uri("/")
         .body(Body::empty())?;
 
-    let response = router.call(request).await?;
+    let response = server.call(request).await?;
 
     assert_eq!(response.status(), StatusCode::OK);
     assert_eq!(


### PR DESCRIPTION
It would be nice to have all HTTP servers automatically log requests in the same way, to ensure they get picked up by OpenTelemetry. This also allows a single version of `axum` to be standardised for handling requests.

This change:
* Adds an `http-server` project in `foundation`
* Updates `today` to use it
