### PR TITLE
feat: use `http-server` in `tag-updater`

### DIFF
--- a/apps/Cargo.lock
+++ b/apps/Cargo.lock
@@ -3977,6 +3977,7 @@ dependencies = [
  "axum-extra",
  "color-eyre",
  "foundation-configuration",
+ "foundation-http-server",
  "foundation-logging",
  "foundation-telemetry",
  "git2",

--- a/apps/tag-updater/Cargo.toml
+++ b/apps/tag-updater/Cargo.toml
@@ -10,6 +10,7 @@ axum = "0.8.4"
 axum-extra = { version = "0.10.1", features = ["typed-header"] }
 color-eyre = { version = "0.6.5", default-features = false }
 foundation-configuration = { path = "../foundation/configuration", features = ["external-bytes"] }
+foundation-http-server = { version = "0.1.0", path = "../foundation/http-server" }
 foundation-logging = { path = "../foundation/logging", version = "0.1.0" }
 foundation-telemetry = { version = "0.1.0", path = "../foundation/telemetry" }
 git2 = { version = "0.20.2", default-features = false, features = ["ssh"] }

--- a/apps/tag-updater/src/main.rs
+++ b/apps/tag-updater/src/main.rs
@@ -2,14 +2,15 @@ use std::net::SocketAddrV4;
 use std::path::Path;
 use std::sync::{Arc, Mutex};
 
+use axum::Json;
 use axum::extract::State;
 use axum::routing::put;
-use axum::{Json, Router};
 use axum_extra::TypedHeader;
 use axum_extra::headers::Authorization;
 use axum_extra::headers::authorization::Bearer;
 use color_eyre::eyre::{Context, Result, eyre};
 use foundation_configuration::{ConfigurationReader, Secret};
+use foundation_http_server::Server;
 use git2::Repository;
 use serde::Deserialize;
 use tokio::net::TcpListener;
@@ -89,14 +90,14 @@ async fn main() -> Result<()> {
         repository,
     };
 
-    let router = Router::new()
+    let server = Server::new()
         .route("/update", put(handle_tag_update))
         .with_state(shared_state);
 
     let addr = SocketAddrV4::new(config.addr, config.port);
     let listener = TcpListener::bind(addr).await?;
 
-    axum::serve(listener, router.into_make_service()).await?;
+    server.run(listener).await?;
 
     Ok(())
 }


### PR DESCRIPTION
The `http-server` library in `foundation` ensures we get consistent traces for all incoming requests, so let's move over towards that.

This change:
* Updates the project to use that
