### PR TITLE
refactor: begin standardising dependencies

### DIFF
--- a/apps/Cargo.toml
+++ b/apps/Cargo.toml
@@ -10,3 +10,8 @@ members = [
 	"today",
 	"utils/application-bootstrap"
 ]
+
+[workspace.dependencies]
+axum = "0.8.4"
+serde = "1.0.219"
+tracing = "0.1.41"

--- a/apps/foundation/configuration/Cargo.toml
+++ b/apps/foundation/configuration/Cargo.toml
@@ -7,10 +7,10 @@ edition = "2024"
 aws-config = { version = "1.8.5", optional = true }
 aws-sdk-s3 = { version = "1.103.0", optional = true }
 color-eyre = { version = "0.6.5", default-features = false }
-serde = { version = "1.0.219", features = ["derive"] }
+serde = { workspace = true, features = ["derive"] }
 serde_yaml = "0.9.34"
 tokio = { version = "1.47.1", features = ["fs"], optional = true }
-tracing = "0.1.41"
+tracing.workspace = true
 
 [features]
 aws-config = ["dep:aws-config"]

--- a/apps/foundation/http-server/Cargo.toml
+++ b/apps/foundation/http-server/Cargo.toml
@@ -8,7 +8,7 @@ axum = "0.8.4"
 tokio = { version = "1.47.1", default-features = false, features = ["net"] }
 tower-http = { version = "0.6.6", features = ["trace"] }
 tower-service = "0.3.3"
-tracing = "0.1.41"
+tracing.workspace = true
 
 [dev-dependencies]
 reqwest = "0.12.23"

--- a/apps/foundation/logging/Cargo.toml
+++ b/apps/foundation/logging/Cargo.toml
@@ -4,6 +4,6 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
-tracing = "0.1.41"
+tracing.workspace = true
 tracing-error = "0.2.1"
 tracing-subscriber = { version = "0.3.19", features = ["env-filter"] }

--- a/apps/foundation/uid/Cargo.toml
+++ b/apps/foundation/uid/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2024"
 
 [dependencies]
 base64 = { version = "0.22.1", optional = true }
-serde = { version = "1.0.219", features = ["derive"], optional = true }
+serde = { workspace = true, features = ["derive"], optional = true }
 sqlx = { version = "0.8.6", default-features = false, optional = true }
 uuid = { version = "1.18.0", features = ["v4"] }
 

--- a/apps/tag-updater/Cargo.toml
+++ b/apps/tag-updater/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2024"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-axum = "0.8.4"
+axum.workspace = true
 axum-extra = { version = "0.10.1", features = ["typed-header"] }
 color-eyre = { version = "0.6.5", default-features = false }
 foundation-configuration = { path = "../foundation/configuration", features = ["external-bytes"] }
@@ -15,7 +15,7 @@ foundation-logging = { path = "../foundation/logging", version = "0.1.0" }
 foundation-telemetry = { version = "0.1.0", path = "../foundation/telemetry" }
 git2 = { version = "0.20.2", default-features = false, features = ["ssh"] }
 pico-args = "0.5.0"
-serde = { version = "1.0.219", features = ["derive"] }
+serde = { workspace = true, features = ["derive"] }
 tokio = { version = "1.47.1", features = ["macros", "rt-multi-thread"] }
-tracing = "0.1.41"
+tracing.workspace = true
 tracing-subscriber = "0.3.20"

--- a/apps/today/Cargo.toml
+++ b/apps/today/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-axum = "0.8.4"
+axum.workspace = true
 chrono = { version = "0.4.38", default-features = false, features = ["now"] }
 color-eyre = "0.6.3"
 dotenvy = "0.15.7"
@@ -16,14 +16,14 @@ foundation-uid = { version = "0.1.0", path = "../foundation/uid" }
 moka = { version = "0.12.8", features = ["future"] }
 pico-args = "0.5.0"
 pulldown-cmark = "0.12.2"
-serde = { version = "1.0.208", features = ["derive"] }
+serde = { workspace = true, features = ["derive"] }
 sqlx = { version = "0.8.0", features = ["postgres", "runtime-tokio-rustls", "uuid", "chrono"] }
 sqlx-bootstrap = { git = "https://github.com/alexander-jackson/sqlx-bootstrap.git", version = "0.1.0" }
 tera = "1.20.0"
 tokio = { version = "1.39.3", features = ["rt-multi-thread", "macros"] }
 tower = { version = "0.5.0", features = ["tracing"] }
 tower-http = { version = "0.5.2", features = ["fs", "trace", "util"] }
-tracing = "0.1.40"
+tracing.workspace = true
 tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }
 uuid = { version = "1.10.0", features = ["serde", "v4"] }
 

--- a/apps/utils/application-bootstrap/Cargo.toml
+++ b/apps/utils/application-bootstrap/Cargo.toml
@@ -8,4 +8,4 @@ clap = { version = "4.5.46", features = ["derive"] }
 color-eyre = "0.6.5"
 foundation-logging = { version = "0.1.0", path = "../../foundation/logging" }
 git2 = { version = "0.20.2", default-features = false }
-tracing = "0.1.41"
+tracing.workspace = true


### PR DESCRIPTION
Some dependencies are used in a few different places, but it would be good to define all the versions in one place so we can just run `cargo check` and it all works out.

This change:
* Begins making some of them workspace dependencies
