### PR TITLE
feat: begin documentation `foundation`

### DIFF
--- a/apps/foundation/configuration/resources/test-configuration.yaml
+++ b/apps/foundation/configuration/resources/test-configuration.yaml
@@ -1,0 +1,5 @@
+name: foobar
+service_type: internal
+socket:
+  addr: 0.0.0.0
+  port: 80

--- a/apps/foundation/telemetry/src/lib.rs
+++ b/apps/foundation/telemetry/src/lib.rs
@@ -10,6 +10,32 @@ use tracing_core::Subscriber;
 use tracing_opentelemetry::OpenTelemetryLayer;
 use tracing_subscriber::registry::LookupSpan;
 
+/// Initialises an [`OpenTelemetryLayer`] and sets up exporting for the service to the given
+/// endpoint.
+///
+/// Defaults to using HTTP for trace exports, as well as a binary protocol.
+///
+/// # Examples
+/// ```
+/// use std::error::Error;
+///
+/// use foundation_telemetry::get_trace_layer;
+/// use tracing_subscriber::layer::SubscriberExt;
+/// use tracing_subscriber::util::SubscriberInitExt;
+///
+/// fn main() -> Result<(), Box<dyn Error>> {
+///     let service = "foobar";
+///     let endpoint = "localhost:4318";
+///
+///     let layer = get_trace_layer(service, endpoint)?;
+///
+///     tracing_subscriber::registry()
+///         .with(layer)
+///         .init();
+///
+///     Ok(())
+/// }
+/// ```
 pub fn get_trace_layer<S, L>(service: S, endpoint: &str) -> Result<OpenTelemetryLayer<L, SdkTracer>>
 where
     S: Into<Value> + Copy,


### PR DESCRIPTION
The `foundation` section of the codebase should probably have reasonable documentation just to encourage sensible API decisions.

This change:
* Adds some basic documentation and tests
