### PR TITLE
feat: improve `http-server` implementation

### DIFF
--- a/apps/Cargo.lock
+++ b/apps/Cargo.lock
@@ -1370,6 +1370,7 @@ dependencies = [
  "reqwest",
  "tokio",
  "tower-http 0.6.6",
+ "tower-layer",
  "tower-service",
  "tracing",
 ]

--- a/apps/foundation/http-server/Cargo.toml
+++ b/apps/foundation/http-server/Cargo.toml
@@ -5,8 +5,9 @@ edition = "2024"
 
 [dependencies]
 axum = "0.8.4"
-tokio = { version = "1.47.1", default-features = false, features = ["net"] }
+tokio = { version = "1.47.1", default-features = false, features = ["net", "signal"] }
 tower-http = { version = "0.6.6", features = ["trace"] }
+tower-layer = "0.3.3"
 tower-service = "0.3.3"
 tracing.workspace = true
 


### PR DESCRIPTION
Some servers are going to need the ability to add custom layers, so let's allow that functionality. Additionally, `forkup` (private) uses a shutdown handler so let's implement that here too so everything can share it.

This change:
* Adds a method to add a layer to a server
* Implements a shutdown handler for the server
