### PR TITLE
feat: extract `init` code

### DIFF
--- a/apps/Cargo.lock
+++ b/apps/Cargo.lock
@@ -1384,6 +1384,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "foundation-init"
+version = "0.1.0"
+dependencies = [
+ "color-eyre",
+ "foundation-args",
+ "foundation-configuration",
+ "foundation-logging",
+ "foundation-telemetry",
+ "serde",
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "foundation-logging"
 version = "0.1.0"
 dependencies = [
@@ -1400,6 +1414,7 @@ dependencies = [
  "opentelemetry",
  "opentelemetry-otlp",
  "opentelemetry_sdk",
+ "serde",
  "tracing-core",
  "tracing-opentelemetry",
  "tracing-subscriber",
@@ -3985,17 +4000,15 @@ dependencies = [
  "axum",
  "axum-extra",
  "color-eyre",
- "foundation-args",
  "foundation-configuration",
  "foundation-http-server",
- "foundation-logging",
+ "foundation-init",
  "foundation-telemetry",
  "git2",
  "pico-args",
  "serde",
  "tokio",
  "tracing",
- "tracing-subscriber",
 ]
 
 [[package]]
@@ -4151,10 +4164,9 @@ dependencies = [
  "chrono",
  "color-eyre",
  "dotenvy",
- "foundation-args",
  "foundation-configuration",
  "foundation-http-server",
- "foundation-logging",
+ "foundation-init",
  "foundation-telemetry",
  "foundation-uid",
  "http-body-util",
@@ -4171,7 +4183,6 @@ dependencies = [
  "tower-http 0.5.2",
  "tower-util",
  "tracing",
- "tracing-subscriber",
  "uuid",
 ]
 

--- a/apps/Cargo.toml
+++ b/apps/Cargo.toml
@@ -4,6 +4,7 @@ members = [
 	"foundation/args",
 	"foundation/configuration",
 	"foundation/http-server",
+	"foundation/init",
 	"foundation/logging",
 	"foundation/telemetry",
 	"foundation/uid",

--- a/apps/foundation/init/Cargo.toml
+++ b/apps/foundation/init/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "foundation-init"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]
+color-eyre = "0.6.5"
+foundation-args = { version = "0.1.0", path = "../args" }
+foundation-configuration = { version = "0.1.0", path = "../configuration" }
+foundation-logging = { version = "0.1.0", path = "../logging" }
+foundation-telemetry = { version = "0.1.0", path = "../telemetry" }
+serde = { workspace = true, features = ["derive"] }
+tracing.workspace = true
+tracing-subscriber = "0.3.20"

--- a/apps/foundation/init/src/lib.rs
+++ b/apps/foundation/init/src/lib.rs
@@ -1,0 +1,61 @@
+use std::ops::Deref;
+
+use color_eyre::eyre::{Result, eyre};
+use foundation_args::Args;
+use foundation_configuration::ConfigurationReader;
+use foundation_telemetry::TelemetryConfig;
+use serde::Deserialize;
+use tracing_subscriber::layer::SubscriberExt;
+use tracing_subscriber::util::SubscriberInitExt;
+
+#[derive(Deserialize)]
+pub struct Configuration<T> {
+    #[serde(flatten)]
+    pub application: T,
+    pub telemetry: Option<TelemetryConfig>,
+}
+
+impl<T> Deref for Configuration<T> {
+    type Target = T;
+
+    fn deref(&self) -> &Self::Target {
+        &self.application
+    }
+}
+
+pub fn run<T>() -> Result<Configuration<T>>
+where
+    T: for<'de> Deserialize<'de>,
+{
+    color_eyre::install()?;
+
+    let current_exe = std::env::current_exe()?;
+
+    let application_name = current_exe
+        .file_stem()
+        .and_then(|s| s.to_str())
+        .ok_or_else(|| eyre!("failed to get current exe file stem"))?
+        .to_owned();
+
+    let args = Args::from_env()?;
+    let config = Configuration::from_yaml(&args.config)?;
+
+    let registry = foundation_logging::get_default_registry();
+
+    match &config.telemetry {
+        Some(telemetry) if telemetry.enabled => {
+            let layer = foundation_telemetry::get_trace_layer(
+                application_name.clone(),
+                &telemetry.endpoint,
+            )?;
+            registry.with(layer).init();
+        }
+        _ => {
+            registry.init();
+        }
+    }
+
+    tracing::info!(name = %application_name, "initialised application");
+
+    Ok(config)
+}

--- a/apps/foundation/telemetry/Cargo.toml
+++ b/apps/foundation/telemetry/Cargo.toml
@@ -8,6 +8,7 @@ color-eyre = { version = "0.6.5", default-features = false }
 opentelemetry = "0.30.0"
 opentelemetry-otlp = "0.30.0"
 opentelemetry_sdk = "0.30.0"
+serde = { workspace = true, features = ["derive"] }
 tracing-core = "0.1.34"
 tracing-opentelemetry = "0.31.0"
 tracing-subscriber = "0.3.19"

--- a/apps/tag-updater/Cargo.toml
+++ b/apps/tag-updater/Cargo.toml
@@ -9,14 +9,12 @@ edition = "2024"
 axum.workspace = true
 axum-extra = { version = "0.10.1", features = ["typed-header"] }
 color-eyre = { version = "0.6.5", default-features = false }
-foundation-args = { path = "../foundation/args" }
 foundation-configuration = { path = "../foundation/configuration", features = ["external-bytes"] }
 foundation-http-server = { version = "0.1.0", path = "../foundation/http-server" }
-foundation-logging = { path = "../foundation/logging", version = "0.1.0" }
+foundation-init = { version = "0.1.0", path = "../foundation/init" }
 foundation-telemetry = { version = "0.1.0", path = "../foundation/telemetry" }
 git2 = { version = "0.20.2", default-features = false, features = ["ssh"] }
 pico-args = "0.5.0"
 serde = { workspace = true, features = ["derive"] }
 tokio = { version = "1.47.1", features = ["macros", "rt-multi-thread"] }
 tracing.workspace = true
-tracing-subscriber = "0.3.20"

--- a/apps/tag-updater/src/config.rs
+++ b/apps/tag-updater/src/config.rs
@@ -4,16 +4,9 @@ use foundation_configuration::{ExternalBytes, Secret};
 use serde::Deserialize;
 
 #[derive(Deserialize)]
-pub struct Config {
+pub struct ApplicationConfiguration {
     pub addr: Ipv4Addr,
     pub port: u16,
     pub passphrase: Secret<String>,
     pub private_key: ExternalBytes,
-    pub telemetry: Option<TelemetryConfig>,
-}
-
-#[derive(Deserialize)]
-pub struct TelemetryConfig {
-    pub enabled: bool,
-    pub endpoint: String,
 }

--- a/apps/today/Cargo.toml
+++ b/apps/today/Cargo.toml
@@ -8,10 +8,9 @@ axum.workspace = true
 chrono = { version = "0.4.38", default-features = false, features = ["now"] }
 color-eyre = "0.6.3"
 dotenvy = "0.15.7"
-foundation-args = { path = "../foundation/args" }
 foundation-configuration = { version = "0.1.0", path = "../foundation/configuration" }
 foundation-http-server = { version = "0.1.0", path = "../foundation/http-server" }
-foundation-logging = { version = "0.1.0", path = "../foundation/logging" }
+foundation-init = { version = "0.1.0", path = "../foundation/init" }
 foundation-telemetry = { version = "0.1.0", path = "../foundation/telemetry" }
 foundation-uid = { version = "0.1.0", path = "../foundation/uid" }
 moka = { version = "0.12.8", features = ["future"] }
@@ -25,7 +24,6 @@ tokio = { version = "1.39.3", features = ["rt-multi-thread", "macros"] }
 tower = { version = "0.5.0", features = ["tracing"] }
 tower-http = { version = "0.5.2", features = ["fs", "trace", "util"] }
 tracing.workspace = true
-tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }
 uuid = { version = "1.10.0", features = ["serde", "v4"] }
 
 [dev-dependencies]

--- a/apps/today/src/config.rs
+++ b/apps/today/src/config.rs
@@ -4,10 +4,9 @@ use foundation_configuration::Secret;
 use serde::Deserialize;
 
 #[derive(Deserialize)]
-pub struct Config {
+pub struct ApplicationConfiguration {
     pub server: ServerConfig,
     pub database: DatabaseConfig,
-    pub telemetry: Option<TelemetryConfig>,
 }
 
 #[derive(Deserialize)]
@@ -29,10 +28,4 @@ pub struct DatabaseConnectionConfig {
     pub username: String,
     pub password: Secret<String>,
     pub database: String,
-}
-
-#[derive(Deserialize)]
-pub struct TelemetryConfig {
-    pub enabled: bool,
-    pub endpoint: String,
 }


### PR DESCRIPTION
Both `today` and `tag-updater` share code to initialise the application (grab some arguments, parse the configuration, set up observability primitives).

This change:
* Adds a `foundation-init` library containing this
