### PR TITLE
feat: make configuration cloneable

### DIFF
--- a/apps/foundation/init/src/lib.rs
+++ b/apps/foundation/init/src/lib.rs
@@ -8,7 +8,7 @@ use serde::Deserialize;
 use tracing_subscriber::layer::SubscriberExt;
 use tracing_subscriber::util::SubscriberInitExt;
 
-#[derive(Deserialize)]
+#[derive(Clone, Debug, Deserialize)]
 pub struct Configuration<T> {
     #[serde(flatten)]
     pub application: T,

--- a/apps/foundation/telemetry/src/lib.rs
+++ b/apps/foundation/telemetry/src/lib.rs
@@ -11,7 +11,7 @@ use tracing_core::Subscriber;
 use tracing_opentelemetry::OpenTelemetryLayer;
 use tracing_subscriber::registry::LookupSpan;
 
-#[derive(Deserialize)]
+#[derive(Clone, Debug, Deserialize)]
 pub struct TelemetryConfig {
     pub enabled: bool,
     pub endpoint: String,


### PR DESCRIPTION
`Configuration<T>` and `TelemetryConfig` don't have some trait derives which would make them easier to use.

This change:
* Adds the necessary derives
