### PR TITLE
feat: add summary statistics

### DIFF
--- a/apps/uptime/.sqlx/query-99b64bcd5c91bb5bc66d68054bf7c3511260c39f1ad84778ffae13256cec9441.json
+++ b/apps/uptime/.sqlx/query-99b64bcd5c91bb5bc66d68054bf7c3511260c39f1ad84778ffae13256cec9441.json
@@ -1,0 +1,22 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            SELECT qf.queried_at\n            FROM query_failure qf\n            JOIN origin o ON o.id = qf.origin_id\n            WHERE o.origin_uid = $1\n            ORDER BY qf.queried_at DESC\n            LIMIT 1\n        ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "queried_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid"
+      ]
+    },
+    "nullable": [
+      false
+    ]
+  },
+  "hash": "99b64bcd5c91bb5bc66d68054bf7c3511260c39f1ad84778ffae13256cec9441"
+}

--- a/apps/uptime/.sqlx/query-d5e088bbd8ab977712c79ca32086f7051d64f3dec6281cc6851e9b315c26717b.json
+++ b/apps/uptime/.sqlx/query-d5e088bbd8ab977712c79ca32086f7051d64f3dec6281cc6851e9b315c26717b.json
@@ -1,0 +1,22 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            SELECT q.queried_at\n            FROM query q\n            JOIN origin o ON o.id = q.origin_id\n            WHERE o.origin_uid = $1\n            ORDER BY q.queried_at DESC\n            LIMIT 1\n        ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "queried_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid"
+      ]
+    },
+    "nullable": [
+      false
+    ]
+  },
+  "hash": "d5e088bbd8ab977712c79ca32086f7051d64f3dec6281cc6851e9b315c26717b"
+}

--- a/apps/uptime/src/persistence.rs
+++ b/apps/uptime/src/persistence.rs
@@ -364,3 +364,45 @@ pub async fn fetch_recent_queries(
 
     Ok(queries)
 }
+
+pub async fn fetch_most_recent_success(
+    pool: &PgPool,
+    origin_uid: Uuid,
+) -> Result<Option<DateTime<Utc>>> {
+    let result = sqlx::query_scalar!(
+        r#"
+            SELECT q.queried_at
+            FROM query q
+            JOIN origin o ON o.id = q.origin_id
+            WHERE o.origin_uid = $1
+            ORDER BY q.queried_at DESC
+            LIMIT 1
+        "#,
+        origin_uid
+    )
+    .fetch_optional(pool)
+    .await?;
+
+    Ok(result)
+}
+
+pub async fn fetch_most_recent_failure(
+    pool: &PgPool,
+    origin_uid: Uuid,
+) -> Result<Option<DateTime<Utc>>> {
+    let result = sqlx::query_scalar!(
+        r#"
+            SELECT qf.queried_at
+            FROM query_failure qf
+            JOIN origin o ON o.id = qf.origin_id
+            WHERE o.origin_uid = $1
+            ORDER BY qf.queried_at DESC
+            LIMIT 1
+        "#,
+        origin_uid
+    )
+    .fetch_optional(pool)
+    .await?;
+
+    Ok(result)
+}

--- a/apps/uptime/templates/origin.tera.html
+++ b/apps/uptime/templates/origin.tera.html
@@ -99,10 +99,21 @@
                             Visit
                         </a>
                     </div>
-                    <div class="grid grid-cols-1 md:grid-cols-3 gap-4 mt-4">
+                    <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4 mt-4">
                         <div class="bg-gray-50 dark:bg-gray-900 rounded-lg p-4">
-                            <p class="text-sm font-medium text-gray-600 dark:text-gray-400">Origin UID</p>
-                            <p class="mt-1 text-sm font-mono text-gray-900 dark:text-white break-all">{{ origin_uid }}</p>
+                            <p class="text-sm font-medium text-gray-600 dark:text-gray-400">Current Status</p>
+                            <div class="mt-1 flex items-center">
+                                {% if health.status == "healthy" %}
+                                <div class="w-2 h-2 bg-green-400 rounded-full mr-2"></div>
+                                <span class="text-lg font-semibold text-green-600 dark:text-green-400">Healthy</span>
+                                {% elif health.status == "down" %}
+                                <div class="w-2 h-2 bg-red-400 rounded-full mr-2"></div>
+                                <span class="text-lg font-semibold text-red-600 dark:text-red-400">Down</span>
+                                {% else %}
+                                <div class="w-2 h-2 bg-gray-400 rounded-full mr-2"></div>
+                                <span class="text-lg font-semibold text-gray-600 dark:text-gray-400">Unknown</span>
+                                {% endif %}
+                            </div>
                         </div>
                         <div class="bg-gray-50 dark:bg-gray-900 rounded-lg p-4">
                             <p class="text-sm font-medium text-gray-600 dark:text-gray-400">Total Recent Queries</p>
@@ -120,6 +131,32 @@
                                 {% endif %}
                             </p>
                         </div>
+                        <div class="bg-gray-50 dark:bg-gray-900 rounded-lg p-4">
+                            {% if health.status == "healthy" %}
+                                {% if health.last_failure %}
+                                <p class="text-sm font-medium text-gray-600 dark:text-gray-400">Last Failed</p>
+                                <p class="mt-1 text-lg font-semibold text-gray-900 dark:text-white">{{ health.last_failure }} ago</p>
+                                {% else %}
+                                <p class="text-sm font-medium text-gray-600 dark:text-gray-400">Last Failed</p>
+                                <p class="mt-1 text-lg font-semibold text-gray-600 dark:text-gray-400">Never</p>
+                                {% endif %}
+                            {% elif health.status == "down" %}
+                                {% if health.last_success %}
+                                <p class="text-sm font-medium text-gray-600 dark:text-gray-400">Last Succeeded</p>
+                                <p class="mt-1 text-lg font-semibold text-gray-900 dark:text-white">{{ health.last_success }} ago</p>
+                                {% else %}
+                                <p class="text-sm font-medium text-gray-600 dark:text-gray-400">Last Succeeded</p>
+                                <p class="mt-1 text-lg font-semibold text-gray-600 dark:text-gray-400">Never</p>
+                                {% endif %}
+                            {% else %}
+                                <p class="text-sm font-medium text-gray-600 dark:text-gray-400">No Data</p>
+                                <p class="mt-1 text-lg font-semibold text-gray-600 dark:text-gray-400">-</p>
+                            {% endif %}
+                        </div>
+                    </div>
+                    <div class="mt-4 bg-gray-50 dark:bg-gray-900 rounded-lg p-4">
+                        <p class="text-sm font-medium text-gray-600 dark:text-gray-400">Origin UID</p>
+                        <p class="mt-1 text-sm font-mono text-gray-900 dark:text-white break-all">{{ origin_uid }}</p>
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
At the moment we only show the last 5 queries, but it would be good to also show the last success or failure depending on the current state of the origin.

This change:
* Adds queries and templates for this
