### PR TITLE
refactor: add type for duration formatting

### DIFF
--- a/apps/uptime/Justfile
+++ b/apps/uptime/Justfile
@@ -1,0 +1,15 @@
+default: run
+
+run:
+	cargo run
+
+test:
+	cargo nextest run
+
+lint:
+	cargo clippy -- -D warnings
+
+format:
+	cargo fmt
+
+validate: lint format test

--- a/apps/uptime/templates/index.tera.html
+++ b/apps/uptime/templates/index.tera.html
@@ -189,7 +189,7 @@
                                         <span class="font-mono">{{ origin.latency_millis }}ms</span>
                                     </td>
                                     <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-600 dark:text-gray-400">
-                                        {{ origin.queried }} ago
+                                        {{ origin.queried }}
                                     </td>
                                 </tr>
                                 {% endfor %}
@@ -242,7 +242,7 @@
                                         </span>
                                     </td>
                                     <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-600 dark:text-gray-400">
-                                        {{ origin.queried }} ago
+                                        {{ origin.queried }}
                                     </td>
                                 </tr>
                                 {% endfor %}

--- a/apps/uptime/templates/origin.tera.html
+++ b/apps/uptime/templates/origin.tera.html
@@ -135,7 +135,7 @@
                             {% if health.status == "healthy" %}
                                 {% if health.last_failure %}
                                 <p class="text-sm font-medium text-gray-600 dark:text-gray-400">Last Failed</p>
-                                <p class="mt-1 text-lg font-semibold text-gray-900 dark:text-white">{{ health.last_failure }} ago</p>
+                                <p class="mt-1 text-lg font-semibold text-gray-900 dark:text-white">{{ health.last_failure }}</p>
                                 {% else %}
                                 <p class="text-sm font-medium text-gray-600 dark:text-gray-400">Last Failed</p>
                                 <p class="mt-1 text-lg font-semibold text-gray-600 dark:text-gray-400">Never</p>
@@ -143,7 +143,7 @@
                             {% elif health.status == "down" %}
                                 {% if health.last_success %}
                                 <p class="text-sm font-medium text-gray-600 dark:text-gray-400">Last Succeeded</p>
-                                <p class="mt-1 text-lg font-semibold text-gray-900 dark:text-white">{{ health.last_success }} ago</p>
+                                <p class="mt-1 text-lg font-semibold text-gray-900 dark:text-white">{{ health.last_success }}</p>
                                 {% else %}
                                 <p class="text-sm font-medium text-gray-600 dark:text-gray-400">Last Succeeded</p>
                                 <p class="mt-1 text-lg font-semibold text-gray-600 dark:text-gray-400">Never</p>
@@ -212,7 +212,7 @@
                                         {% endif %}
                                     </td>
                                     <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-600 dark:text-gray-400">
-                                        {{ query.queried }} ago
+                                        {{ query.queried }}
                                     </td>
                                 </tr>
                                 {% endfor %}


### PR DESCRIPTION
Currently we do duration formatting in a few places before we return it to `tera` for templating, so let's just have a type that does this.

This change:
* Adds a `PrettyDuration` type
* Uses it everywhere
