### PR TITLE
feat: use SSL for backups

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -46,6 +46,12 @@ Shared libraries in `apps/foundation/`:
 
 ## Development Commands
 
+### Adding Dependencies
+```bash
+# Use cargo add — do not edit Cargo.toml manually
+cargo add <crate> -p <package>
+```
+
 ### Building
 ```bash
 # Build all workspace members

--- a/apps/Cargo.lock
+++ b/apps/Cargo.lock
@@ -3637,7 +3637,9 @@ dependencies = [
  "foundation-credentials",
  "foundation-init",
  "humansize",
+ "native-tls",
  "pico-args",
+ "postgres-native-tls",
  "serde",
  "tokio",
  "tokio-postgres",
@@ -3809,6 +3811,18 @@ name = "portable-atomic"
 version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
+
+[[package]]
+name = "postgres-native-tls"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fef4de47bb81477e0c3deaf153a1b10ae176484713ff1640969f4cb96b653ebc"
+dependencies = [
+ "native-tls",
+ "tokio",
+ "tokio-native-tls",
+ "tokio-postgres",
+]
 
 [[package]]
 name = "postgres-protocol"

--- a/apps/pgmanager/Cargo.toml
+++ b/apps/pgmanager/Cargo.toml
@@ -12,7 +12,9 @@ foundation-configuration = { version = "0.1.0", path = "../foundation/configurat
 foundation-credentials = { version = "0.1.0", path = "../foundation/credentials" }
 foundation-init = { version = "0.1.0", path = "../foundation/init" }
 humansize = "2.1.3"
+native-tls = "0.2.18"
 pico-args = "0.5.0"
+postgres-native-tls = "0.5.3"
 serde = { workspace = true, features = ["derive"] }
 tokio = { version = "1.40.0", features = ["macros", "process", "rt", "time"] }
 tokio-postgres = "0.7.11"

--- a/apps/pgmanager/src/config.rs
+++ b/apps/pgmanager/src/config.rs
@@ -32,6 +32,8 @@ pub struct TargetDatabaseConfiguration {
     pub database: String,
     pub host: String,
     pub port: u16,
+    #[serde(default)]
+    pub ssl: bool,
 }
 
 impl From<&TargetDatabaseConfiguration> for tokio_postgres::Config {

--- a/apps/pgmanager/src/databases.rs
+++ b/apps/pgmanager/src/databases.rs
@@ -43,6 +43,10 @@ pub async fn dump(config: &TargetDatabaseConfiguration, database: &str) -> Resul
         ])
         .stdout(Stdio::piped());
 
+    if config.ssl {
+        command.env("PGSSLMODE", "require");
+    }
+
     if let Some(password) = config.password.as_deref() {
         command.env("PGPASSWORD", password);
     }

--- a/apps/pgmanager/src/main.rs
+++ b/apps/pgmanager/src/main.rs
@@ -3,6 +3,8 @@ use std::time::Duration;
 use aws_sdk_s3::primitives::ByteStream;
 use chrono::Utc;
 use color_eyre::eyre::Result;
+use native_tls::TlsConnector;
+use postgres_native_tls::MakeTlsConnector;
 use tokio::time::Instant;
 use tokio_postgres::NoTls;
 
@@ -53,15 +55,30 @@ async fn take_backups(
     let span = tracing::info_span!("backup", %date);
     let _guard = span.enter();
 
-    let (client, connection) = tokio_postgres::Config::from(database_config)
-        .connect(NoTls)
-        .await?;
-
-    tokio::spawn(async move {
-        if let Err(e) = connection.await {
-            eprintln!("connection error: {}", e);
-        }
-    });
+    let client = if database_config.ssl {
+        let tls = TlsConnector::builder()
+            .danger_accept_invalid_certs(true)
+            .build()?;
+        let (client, connection) = tokio_postgres::Config::from(database_config)
+            .connect(MakeTlsConnector::new(tls))
+            .await?;
+        tokio::spawn(async move {
+            if let Err(e) = connection.await {
+                eprintln!("connection error: {}", e);
+            }
+        });
+        client
+    } else {
+        let (client, connection) = tokio_postgres::Config::from(database_config)
+            .connect(NoTls)
+            .await?;
+        tokio::spawn(async move {
+            if let Err(e) = connection.await {
+                eprintln!("connection error: {}", e);
+            }
+        });
+        client
+    };
 
     let databases = discover(&client).await?;
 

--- a/infrastructure/configuration/pgmanager/config.yaml
+++ b/infrastructure/configuration/pgmanager/config.yaml
@@ -4,7 +4,7 @@ backup_location:
 
 backup_schedule:
   type: daily
-  time: 22:30
+  time: 11:30
 
 target_database:
   username: postgres
@@ -12,3 +12,4 @@ target_database:
   database: postgres
   host: rds.mesh.internal
   port: 5432
+  ssl: true


### PR DESCRIPTION
Now that production has been migrated to using RDS, the backups aren't working as the application doesn't use SSL to connect in (which RDS requires).

This change:
* Updates both the connection and the `pg_dump` command to use SSL
* Updates backups to run at 11:30 for a little bit
