### PR TITLE
feat: ignore `rdsadmin` database

### DIFF
--- a/apps/pgmanager/src/databases.rs
+++ b/apps/pgmanager/src/databases.rs
@@ -14,7 +14,8 @@ pub async fn discover(client: &Client) -> Result<Vec<String>> {
         WHERE datname NOT IN (
             'postgres',
             'template0',
-            'template1'
+            'template1',
+            'rdsadmin'
         )
     "#;
 


### PR DESCRIPTION
The instance in production can't even connect to this database so it's just producing meaningless backups of 0 bytes (which get compressed into 20 bytes). There's nothing useful in here anyway.

This change:
* Ignores the `rdsadmin` database
