### PR TITLE
feat: handle timezone issues

### DIFF
--- a/apps/Cargo.lock
+++ b/apps/Cargo.lock
@@ -1623,6 +1623,7 @@ version = "0.1.0"
 dependencies = [
  "axum",
  "chrono",
+ "chrono-tz",
  "color-eyre",
  "foundation-http-server",
  "foundation-init",

--- a/apps/events/Cargo.toml
+++ b/apps/events/Cargo.toml
@@ -10,6 +10,7 @@ path = "src/main.rs"
 [dependencies]
 axum.workspace = true
 chrono = { version = "0.4.38", default-features = false, features = ["now", "serde"] }
+chrono-tz = "0.9.0"
 color-eyre = "0.6.3"
 foundation-http-server = { version = "0.1.0", path = "../foundation/http-server" }
 foundation-init = { version = "0.1.0", path = "../foundation/init", features = ["database"] }

--- a/apps/events/src/server.rs
+++ b/apps/events/src/server.rs
@@ -6,7 +6,8 @@ use axum::http::header::LOCATION;
 use axum::response::Response;
 use axum::routing::{get, post};
 use chrono::{DateTime, Local, NaiveDateTime, Utc};
-use color_eyre::eyre::Result;
+use chrono_tz::Tz;
+use color_eyre::eyre::{Result, eyre};
 use foundation_http_server::Server;
 use foundation_templating::{RenderedTemplate, TemplateEngine};
 use serde::{Deserialize, Deserializer};
@@ -17,23 +18,21 @@ use crate::error::ServerResult;
 use crate::persistence::EventType;
 use crate::templates::{HistoryContext, IndexContext};
 
-#[derive(Debug)]
-struct OccurredAt(DateTime<Utc>);
-
-impl Default for OccurredAt {
-    fn default() -> Self {
-        OccurredAt(Utc::now())
-    }
+#[derive(Debug, Default)]
+enum OccurredAt {
+    #[default]
+    Now,
+    Explicit(NaiveDateTime),
 }
 
 impl<'de> Deserialize<'de> for OccurredAt {
     fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
         let s = String::deserialize(deserializer)?;
         if s.is_empty() {
-            return Ok(OccurredAt::default());
+            return Ok(OccurredAt::Now);
         }
         NaiveDateTime::parse_from_str(&s, "%Y-%m-%dT%H:%M")
-            .map(|dt| OccurredAt(dt.and_utc()))
+            .map(OccurredAt::Explicit)
             .map_err(serde::de::Error::custom)
     }
 }
@@ -42,6 +41,36 @@ impl<'de> Deserialize<'de> for OccurredAt {
 struct EventForm {
     #[serde(default)]
     occurred_at: OccurredAt,
+    #[serde(default)]
+    timezone: String,
+}
+
+impl EventForm {
+    fn into_utc(self) -> Result<DateTime<Utc>> {
+        match self.occurred_at {
+            OccurredAt::Now => Ok(Utc::now()),
+            OccurredAt::Explicit(naive) => {
+                if self.timezone.is_empty() {
+                    return Ok(naive.and_utc());
+                }
+                let tz: Tz = self
+                    .timezone
+                    .parse()
+                    .map_err(|_| eyre!("unknown timezone: {:?}", self.timezone))?;
+                naive
+                    .and_local_timezone(tz)
+                    .earliest()
+                    .map(|dt| dt.to_utc())
+                    .ok_or_else(|| {
+                        eyre!(
+                            "datetime {:?} does not exist in timezone {:?}",
+                            naive,
+                            self.timezone
+                        )
+                    })
+            }
+        }
+    }
 }
 
 #[derive(Clone)]
@@ -107,7 +136,7 @@ async fn insert(
     State(ApplicationState { pool, .. }): State<ApplicationState>,
     Form(form): Form<EventForm>,
 ) -> ServerResult<Response> {
-    crate::persistence::record_event(&pool, EventType::Inserted, form.occurred_at.0).await?;
+    crate::persistence::record_event(&pool, EventType::Inserted, form.into_utc()?).await?;
     tracing::info!("recorded insert event");
     Ok(redirect("/")?)
 }
@@ -117,7 +146,7 @@ async fn remove(
     State(ApplicationState { pool, .. }): State<ApplicationState>,
     Form(form): Form<EventForm>,
 ) -> ServerResult<Response> {
-    crate::persistence::record_event(&pool, EventType::Removed, form.occurred_at.0).await?;
+    crate::persistence::record_event(&pool, EventType::Removed, form.into_utc()?).await?;
     tracing::info!("recorded remove event");
     Ok(redirect("/")?)
 }
@@ -133,52 +162,78 @@ fn redirect(path: &'static str) -> Result<Response> {
 
 #[cfg(test)]
 mod tests {
-    use chrono::{Duration, Utc};
+    use chrono::{DateTime, Duration, Utc};
     use serde::Deserialize;
     use serde::de::IntoDeserializer;
 
-    use super::OccurredAt;
+    use super::{EventForm, OccurredAt};
 
-    fn parse(s: &str) -> Result<OccurredAt, serde::de::value::Error> {
+    fn parse_naive(s: &str) -> Result<OccurredAt, serde::de::value::Error> {
         OccurredAt::deserialize(s.into_deserializer())
     }
 
-    #[test]
-    fn default_falls_back_to_now() {
-        let before = Utc::now();
-        let result = OccurredAt::default();
-        let after = Utc::now();
-        assert!(result.0 >= before && result.0 <= after);
+    fn to_utc(occurred_at: &str, timezone: &str) -> color_eyre::eyre::Result<DateTime<Utc>> {
+        let form = EventForm {
+            occurred_at: parse_naive(occurred_at).map_err(|e| color_eyre::eyre::eyre!("{e}"))?,
+            timezone: timezone.to_string(),
+        };
+        form.into_utc()
     }
 
     #[test]
     fn empty_string_falls_back_to_now() {
         let before = Utc::now();
-        let result = parse("").unwrap();
+        let result = to_utc("", "").unwrap();
         let after = Utc::now();
-        assert!(result.0 >= before && result.0 <= after);
+        assert!(result >= before && result <= after);
     }
 
     #[test]
-    fn valid_datetime_is_parsed_as_utc() {
-        let result = parse("2026-03-18T09:30").unwrap();
-        assert_eq!(result.0.to_rfc3339(), "2026-03-18T09:30:00+00:00");
+    fn empty_timezone_with_explicit_time_falls_back_to_utc() {
+        let result = to_utc("2026-03-18T09:30", "").unwrap();
+        assert_eq!(result.to_rfc3339(), "2026-03-18T09:30:00+00:00");
     }
 
     #[test]
     fn invalid_datetime_returns_error() {
-        assert!(parse("not-a-date").is_err());
+        assert!(parse_naive("not-a-date").is_err());
     }
 
     #[test]
     fn parsed_time_has_no_seconds() {
-        let result = parse("2026-03-18T09:30").unwrap();
-        assert_eq!(result.0.timestamp() % 60, 0);
+        let result = to_utc("2026-03-18T09:30", "").unwrap();
+        assert_eq!(result.timestamp() % 60, 0);
     }
 
     #[test]
     fn past_datetime_is_before_now() {
-        let result = parse("2020-01-01T00:00").unwrap();
-        assert!(result.0 < Utc::now() - Duration::days(365));
+        let result = to_utc("2020-01-01T00:00", "").unwrap();
+        assert!(result < Utc::now() - Duration::days(365));
+    }
+
+    #[test]
+    fn london_summer_time_converted_to_utc() {
+        // Europe/London is UTC+1 in summer (BST)
+        let result = to_utc("2026-07-01T10:00", "Europe/London").unwrap();
+        assert_eq!(result.to_rfc3339(), "2026-07-01T09:00:00+00:00");
+    }
+
+    #[test]
+    fn london_winter_time_converted_to_utc() {
+        // Europe/London is UTC+0 in winter (GMT)
+        let result = to_utc("2026-01-01T10:00", "Europe/London").unwrap();
+        assert_eq!(result.to_rfc3339(), "2026-01-01T10:00:00+00:00");
+    }
+
+    #[test]
+    fn new_york_winter_time_converted_to_utc() {
+        // America/New_York is UTC-5 in winter (EST)
+        let result = to_utc("2026-01-01T10:00", "America/New_York").unwrap();
+        assert_eq!(result.to_rfc3339(), "2026-01-01T15:00:00+00:00");
+    }
+
+    #[test]
+    fn invalid_timezone_returns_error() {
+        assert!(to_utc("2026-01-01T10:00", "Fake/Timezone").is_err());
     }
 }

--- a/apps/events/templates/index.tera.html
+++ b/apps/events/templates/index.tera.html
@@ -94,6 +94,7 @@
             <div>
                 {% if is_inserted %}
                 <form action="/remove" method="POST">
+                    <input type="hidden" name="timezone" value="" />
                     <button
                         type="submit"
                         class="w-full px-6 py-4 bg-red-600/20 hover:bg-red-600/30 text-red-400 border border-red-600/40 font-semibold text-lg rounded-lg transition-colors duration-200 focus:outline-none focus:ring-2 focus:ring-red-500 focus:ring-offset-2 focus:ring-offset-dark-bg"
@@ -115,6 +116,7 @@
                 </form>
                 {% else %}
                 <form action="/insert" method="POST">
+                    <input type="hidden" name="timezone" value="" />
                     <button
                         type="submit"
                         class="w-full px-6 py-4 bg-green-600/20 hover:bg-green-600/30 text-green-400 border border-green-600/40 font-semibold text-lg rounded-lg transition-colors duration-200 focus:outline-none focus:ring-2 focus:ring-green-500 focus:ring-offset-2 focus:ring-offset-dark-bg"
@@ -139,5 +141,17 @@
 
         </main>
     </div>
+    <script>
+        (function () {
+            var tz = '';
+            try { tz = Intl.DateTimeFormat().resolvedOptions().timeZone || ''; } catch (e) {}
+            document.querySelectorAll('form').forEach(function (form) {
+                form.addEventListener('submit', function () {
+                    var field = form.querySelector('input[name="timezone"]');
+                    if (field) field.value = tz;
+                });
+            });
+        })();
+    </script>
 </body>
 </html>


### PR DESCRIPTION
Now that London is on BST (or if the user is abroad), the time ended on the main page doesn't match up with the time that gets stored in the database as it's not aware of what time the user meant.

This change:
* Records timezone information alongside the provided timestamp
* Converts to UTC for storing in the database
