### PR TITLE
tests: add recurring job validation

### DIFF
--- a/apps/foundation/recurring-job/Cargo.toml
+++ b/apps/foundation/recurring-job/Cargo.toml
@@ -8,3 +8,6 @@ color-eyre = "0.6.5"
 foundation-shutdown = { path = "../shutdown" }
 tokio = { version = "1.48.0", default-features = false, features = ["macros", "time"] }
 tracing.workspace = true
+
+[dev-dependencies]
+tokio = { version = "1.48.0", default-features = false, features = ["macros", "rt", "time"] }

--- a/apps/foundation/recurring-job/src/lib.rs
+++ b/apps/foundation/recurring-job/src/lib.rs
@@ -56,3 +56,76 @@ where
         Ok(())
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::time::Duration;
+
+    use foundation_shutdown::{CancellationToken, GracefulTask};
+    use tokio::sync::Mutex;
+    use tokio::sync::mpsc::{Receiver, Sender};
+
+    use crate::RecurringJob;
+
+    struct State {
+        counter: AtomicUsize,
+        sender: Sender<()>,
+        receiver: Mutex<Receiver<()>>,
+    }
+
+    #[tokio::test]
+    async fn can_create_and_run_recurring_job() {
+        let counter = AtomicUsize::new(0);
+
+        let (test_sender, job_receiver) = tokio::sync::mpsc::channel(1);
+        let (job_sender, mut test_receiver) = tokio::sync::mpsc::channel(1);
+
+        let state = Arc::new(State {
+            counter,
+            sender: job_sender,
+            receiver: Mutex::new(job_receiver),
+        });
+
+        let job = RecurringJob::new(
+            "test-job",
+            Duration::from_millis(1),
+            Arc::clone(&state),
+            |state| {
+                Box::pin(async move {
+                    // wait for a message
+                    state.receiver.lock().await.recv().await;
+
+                    // do some work
+                    state.counter.fetch_add(1, Ordering::SeqCst);
+
+                    // notify the test that the job has been run
+                    state.sender.send(()).await.unwrap();
+
+                    Ok(())
+                })
+            },
+        );
+
+        let shutdown_token = CancellationToken::new();
+        let job_token = shutdown_token.clone();
+
+        tokio::spawn(async move {
+            job.run_until_shutdown(job_token).await.unwrap();
+        });
+
+        // trigger the job a couple of times
+        let iterations = 3;
+
+        for _ in 0..iterations {
+            test_sender.send(()).await.unwrap();
+            test_receiver.recv().await.unwrap();
+        }
+
+        // check the counter has been incremented the expected number of times
+        assert_eq!(state.counter.load(Ordering::SeqCst), iterations);
+
+        shutdown_token.cancel();
+    }
+}

--- a/apps/foundation/shutdown/Cargo.toml
+++ b/apps/foundation/shutdown/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2024"
 
 [dependencies]
 color-eyre = "0.6.5"
-tokio = { version = "1.48.0", default-features = false, features = ["macros", "signal", "sync"] }
+tokio = { version = "1.48.0", default-features = false, features = ["macros", "rt", "signal", "sync"] }
 tokio-util = "0.7.17"
 tracing.workspace = true
 


### PR DESCRIPTION
In order to make changes to the API of `recurring-job`, it would be good to have a sample implementation local to the crate to fiddle around with.

This change:
* Adds a basic test that creates a recurring job and runs it
