### PR TITLE
refactor: make jobs nicer

### DIFF
--- a/apps/certmanager/src/main.rs
+++ b/apps/certmanager/src/main.rs
@@ -1,6 +1,7 @@
 use std::net::SocketAddrV4;
 
 use color_eyre::eyre::Result;
+use foundation_recurring_job::RecurringJob;
 use foundation_shutdown::ShutdownCoordinator;
 use foundation_templating::TemplateEngine;
 use tokio::net::TcpListener;
@@ -49,7 +50,7 @@ async fn main() -> Result<()> {
 
     ShutdownCoordinator::new()
         .with_task(server)
-        .with_task(watcher)
+        .with_task(RecurringJob::new(watcher))
         .run()
         .await?;
 

--- a/apps/certmanager/src/watcher.rs
+++ b/apps/certmanager/src/watcher.rs
@@ -1,7 +1,7 @@
 use std::time::Duration;
 
 use color_eyre::eyre::Result;
-use foundation_shutdown::{CancellationToken, GracefulTask};
+use foundation_recurring_job::Job;
 use sqlx::PgPool;
 use sqlx::types::chrono::Utc;
 
@@ -16,8 +16,13 @@ impl Watcher {
     pub fn new(renewer: Renewer, pool: PgPool) -> Self {
         Self { renewer, pool }
     }
+}
 
-    async fn poll(&self) -> Result<()> {
+impl Job for Watcher {
+    const NAME: &'static str = "Certificate Expiry Watcher";
+    const INTERVAL: Duration = Duration::from_hours(1);
+
+    async fn run(&self) -> Result<()> {
         // Find the certificate next expiring
         let expiries = crate::persistence::select_latest_expiry_per_domain(&self.pool).await?;
 
@@ -88,26 +93,6 @@ impl Watcher {
             %certificate_uid,
             "Certificate renewed and stored in database"
         );
-
-        Ok(())
-    }
-}
-
-impl GracefulTask for Watcher {
-    async fn run_until_shutdown(self, shutdown: CancellationToken) -> Result<()> {
-        loop {
-            tokio::select! {
-                _ = shutdown.cancelled() => {
-                    tracing::info!("Watcher received shutdown signal, exiting...");
-                    break;
-                }
-                result = self.poll() => {
-                    if let Err(e) = result {
-                        tracing::error!(?e, "Error while polling for certificate expiries");
-                    }
-                }
-            }
-        }
 
         Ok(())
     }

--- a/apps/foundation/recurring-job/src/lib.rs
+++ b/apps/foundation/recurring-job/src/lib.rs
@@ -1,53 +1,43 @@
 use std::future::Future;
-use std::pin::Pin;
 use std::time::Duration;
 
 use color_eyre::eyre::Result;
 use foundation_shutdown::{CancellationToken, GracefulTask};
 
-pub struct RecurringJob<T, F>
-where
-    T: Send + 'static,
-    F: for<'a> Fn(&'a T) -> Pin<Box<dyn Future<Output = Result<()>> + Send + 'a>> + Send + 'static,
-{
-    name: String,
-    interval: Duration,
-    state: T,
-    job: F,
+pub trait Job: Send + 'static {
+    const NAME: &'static str;
+    const INTERVAL: Duration;
+
+    fn run(&self) -> impl Future<Output = Result<()>> + Send + '_;
 }
 
-impl<T, F> RecurringJob<T, F>
+pub struct RecurringJob<T>
 where
-    T: Send + 'static,
-    F: for<'a> Fn(&'a T) -> Pin<Box<dyn Future<Output = Result<()>> + Send + 'a>> + Send + 'static,
+    T: Job,
 {
-    pub fn new(name: impl Into<String>, interval: Duration, state: T, job: F) -> Self {
-        Self {
-            name: name.into(),
-            interval,
-            state,
-            job,
-        }
+    state: T,
+}
+
+impl<T: Job> RecurringJob<T> {
+    pub fn new(state: T) -> Self {
+        Self { state }
     }
 }
 
-impl<T, F> GracefulTask for RecurringJob<T, F>
-where
-    T: Send + 'static,
-    F: for<'a> Fn(&'a T) -> Pin<Box<dyn Future<Output = Result<()>> + Send + 'a>> + Send + 'static,
-{
+impl<T: Job> GracefulTask for RecurringJob<T> {
     async fn run_until_shutdown(self, shutdown: CancellationToken) -> Result<()> {
-        let mut interval = tokio::time::interval(self.interval);
+        let mut interval = tokio::time::interval(T::INTERVAL);
+        let job = T::NAME;
 
         loop {
             tokio::select! {
                 _ = shutdown.cancelled() => {
-                    tracing::info!(job = %self.name, "shutting down gracefully");
+                    tracing::info!(%job, "shutting down gracefully");
                     break;
                 }
                 _ = interval.tick() => {
-                    if let Err(e) = (self.job)(&self.state).await {
-                        tracing::warn!(job = %self.name, error = ?e, "job execution failed");
+                    if let Err(e) = self.state.run().await {
+                        tracing::warn!(%job, error = ?e, "job execution failed");
                     }
                 }
             }
@@ -59,54 +49,52 @@ where
 
 #[cfg(test)]
 mod tests {
+    use std::future::Future;
     use std::sync::Arc;
     use std::sync::atomic::{AtomicUsize, Ordering};
     use std::time::Duration;
 
+    use color_eyre::eyre::Result;
     use foundation_shutdown::{CancellationToken, GracefulTask};
     use tokio::sync::Mutex;
     use tokio::sync::mpsc::{Receiver, Sender};
 
-    use crate::RecurringJob;
+    use crate::{Job, RecurringJob};
 
-    struct State {
-        counter: AtomicUsize,
+    struct TestJob {
+        counter: Arc<AtomicUsize>,
         sender: Sender<()>,
         receiver: Mutex<Receiver<()>>,
     }
 
+    impl Job for TestJob {
+        const NAME: &'static str = "test-job";
+        const INTERVAL: Duration = Duration::from_millis(1);
+
+        fn run(&self) -> impl Future<Output = Result<()>> + Send + '_ {
+            async move {
+                self.receiver.lock().await.recv().await;
+                self.counter.fetch_add(1, Ordering::SeqCst);
+                self.sender.send(()).await.unwrap();
+
+                Ok(())
+            }
+        }
+    }
+
     #[tokio::test]
     async fn can_create_and_run_recurring_job() {
-        let counter = AtomicUsize::new(0);
-
+        let counter = Arc::new(AtomicUsize::new(0));
         let (test_sender, job_receiver) = tokio::sync::mpsc::channel(1);
         let (job_sender, mut test_receiver) = tokio::sync::mpsc::channel(1);
 
-        let state = Arc::new(State {
-            counter,
+        let job = TestJob {
+            counter: counter.clone(),
             sender: job_sender,
             receiver: Mutex::new(job_receiver),
-        });
+        };
 
-        let job = RecurringJob::new(
-            "test-job",
-            Duration::from_millis(1),
-            Arc::clone(&state),
-            |state| {
-                Box::pin(async move {
-                    // wait for a message
-                    state.receiver.lock().await.recv().await;
-
-                    // do some work
-                    state.counter.fetch_add(1, Ordering::SeqCst);
-
-                    // notify the test that the job has been run
-                    state.sender.send(()).await.unwrap();
-
-                    Ok(())
-                })
-            },
-        );
+        let job = RecurringJob::new(job);
 
         let shutdown_token = CancellationToken::new();
         let job_token = shutdown_token.clone();
@@ -115,7 +103,6 @@ mod tests {
             job.run_until_shutdown(job_token).await.unwrap();
         });
 
-        // trigger the job a couple of times
         let iterations = 3;
 
         for _ in 0..iterations {
@@ -123,8 +110,7 @@ mod tests {
             test_receiver.recv().await.unwrap();
         }
 
-        // check the counter has been incremented the expected number of times
-        assert_eq!(state.counter.load(Ordering::SeqCst), iterations);
+        assert_eq!(counter.load(Ordering::SeqCst), iterations);
 
         shutdown_token.cancel();
     }

--- a/apps/uptime/src/certificate_checker/mod.rs
+++ b/apps/uptime/src/certificate_checker/mod.rs
@@ -1,5 +1,8 @@
+use std::time::Duration;
+
 use chrono::Utc;
 use color_eyre::eyre::Result;
+use foundation_recurring_job::Job;
 use reqwest::Client;
 use sqlx::PgPool;
 use tracing::{error, info};
@@ -17,8 +20,13 @@ impl CertificateChecker {
     pub fn new(pool: PgPool, http_client: Client) -> Self {
         Self { pool, http_client }
     }
+}
 
-    pub async fn check_all_certificates(&self) -> Result<()> {
+impl Job for CertificateChecker {
+    const NAME: &'static str = "Certificate Checker";
+    const INTERVAL: Duration = Duration::from_hours(24);
+
+    async fn run(&self) -> Result<()> {
         let origins = crate::persistence::fetch_origins(&self.pool).await?;
 
         for origin in origins {

--- a/apps/uptime/src/main.rs
+++ b/apps/uptime/src/main.rs
@@ -1,5 +1,3 @@
-use std::time::Duration;
-
 use color_eyre::eyre::Result;
 use foundation_recurring_job::RecurringJob;
 use foundation_shutdown::ShutdownCoordinator;
@@ -36,16 +34,9 @@ async fn main() -> Result<()> {
     let listener = TcpListener::bind(config.server.addr).await?;
     let server = crate::server::build(pool.clone(), listener)?;
 
-    let poller_job = RecurringJob::new("uptime-poller", Duration::from_secs(60), poller, |p| {
-        Box::pin(async { p.query_all_origins().await })
-    });
+    let poller_job = RecurringJob::new(poller);
 
-    let cert_job = RecurringJob::new(
-        "certificate-checker",
-        Duration::from_secs(86400),
-        cert_checker,
-        |c| Box::pin(async { c.check_all_certificates().await }),
-    );
+    let cert_job = RecurringJob::new(cert_checker);
 
     ShutdownCoordinator::new()
         .with_task(poller_job)

--- a/apps/uptime/src/poller/mod.rs
+++ b/apps/uptime/src/poller/mod.rs
@@ -2,6 +2,7 @@ use std::fmt::{self, Display};
 use std::time::Duration;
 
 use color_eyre::eyre::Result;
+use foundation_recurring_job::Job;
 use sqlx::PgPool;
 use sqlx::types::chrono::Utc;
 use uuid::Uuid;
@@ -66,7 +67,12 @@ impl From<reqwest::Error> for FailureReason {
 }
 
 pub trait Notifier {
-    async fn notify(&self, topic: &str, subject: &str, message: &str) -> Result<()>;
+    fn notify(
+        &self,
+        topic: &str,
+        subject: &str,
+        message: &str,
+    ) -> impl Future<Output = Result<()>> + Send;
 }
 
 impl Notifier for aws_sdk_sns::Client {
@@ -157,71 +163,6 @@ impl<N: Notifier> Poller<N> {
             notifier,
             configuration,
         }
-    }
-
-    pub async fn query_all_origins(&self) -> Result<()> {
-        let Self {
-            pool, http_client, ..
-        } = self;
-
-        // Find all the available origins
-        let origins = crate::persistence::fetch_origins(pool).await?;
-        let timeout = Duration::from_secs(3);
-
-        for Origin { origin_uid, uri } in origins {
-            let mut tx = pool.begin().await?;
-            let start = Utc::now();
-
-            match http_client.get(&uri).timeout(timeout).send().await {
-                Ok(res) => {
-                    let status = res.status();
-                    let latency_millis = (Utc::now() - start).num_milliseconds();
-
-                    let query_uid = crate::persistence::insert_query(
-                        &mut tx,
-                        origin_uid,
-                        status.as_u16(),
-                        latency_millis,
-                        start,
-                    )
-                    .await?;
-
-                    tracing::info!(
-                        %origin_uid,
-                        %query_uid,
-                        %status,
-                        %latency_millis,
-                        "made a request to the origin"
-                    );
-                }
-                Err(e) => {
-                    let failure_reason = FailureReason::from(e);
-
-                    let query_failure_uid = crate::persistence::insert_query_failure(
-                        &mut tx,
-                        origin_uid,
-                        failure_reason,
-                        start,
-                    )
-                    .await?;
-
-                    tracing::warn!(
-                        %origin_uid,
-                        %query_failure_uid,
-                        %failure_reason,
-                        "failed to make a request to the origin"
-                    );
-                }
-            }
-
-            tx.commit().await?;
-
-            // Check whether we need to notify someone
-            self.check_for_pending_notifications(origin_uid, &uri)
-                .await?;
-        }
-
-        Ok(())
     }
 
     async fn check_for_pending_notifications(&self, origin_uid: Uuid, uri: &str) -> Result<()> {
@@ -349,6 +290,76 @@ impl<N: Notifier> Poller<N> {
         .await?;
 
         tracing::info!(%origin_uid, %notification_uid, "routed a new notification");
+
+        Ok(())
+    }
+}
+
+impl<N: Notifier + Send + Sync + 'static> Job for Poller<N> {
+    const NAME: &'static str = "Origin Poller";
+    const INTERVAL: Duration = Duration::from_secs(60);
+
+    async fn run(&self) -> Result<()> {
+        let Self {
+            pool, http_client, ..
+        } = self;
+
+        // Find all the available origins
+        let origins = crate::persistence::fetch_origins(pool).await?;
+        let timeout = Duration::from_secs(3);
+
+        for Origin { origin_uid, uri } in origins {
+            let mut tx = pool.begin().await?;
+            let start = Utc::now();
+
+            match http_client.get(&uri).timeout(timeout).send().await {
+                Ok(res) => {
+                    let status = res.status();
+                    let latency_millis = (Utc::now() - start).num_milliseconds();
+
+                    let query_uid = crate::persistence::insert_query(
+                        &mut tx,
+                        origin_uid,
+                        status.as_u16(),
+                        latency_millis,
+                        start,
+                    )
+                    .await?;
+
+                    tracing::info!(
+                        %origin_uid,
+                        %query_uid,
+                        %status,
+                        %latency_millis,
+                        "made a request to the origin"
+                    );
+                }
+                Err(e) => {
+                    let failure_reason = FailureReason::from(e);
+
+                    let query_failure_uid = crate::persistence::insert_query_failure(
+                        &mut tx,
+                        origin_uid,
+                        failure_reason,
+                        start,
+                    )
+                    .await?;
+
+                    tracing::warn!(
+                        %origin_uid,
+                        %query_failure_uid,
+                        %failure_reason,
+                        "failed to make a request to the origin"
+                    );
+                }
+            }
+
+            tx.commit().await?;
+
+            // Check whether we need to notify someone
+            self.check_for_pending_notifications(origin_uid, &uri)
+                .await?;
+        }
 
         Ok(())
     }

--- a/apps/uptime/src/poller/tests.rs
+++ b/apps/uptime/src/poller/tests.rs
@@ -3,6 +3,7 @@ use std::sync::Arc;
 
 use chrono::Duration;
 use color_eyre::eyre::Result;
+use foundation_recurring_job::Job;
 use sqlx::PgPool;
 use tokio::sync::RwLock;
 use uuid::Uuid;
@@ -104,7 +105,7 @@ async fn can_query_all_origins(pool: PgPool) -> Result<()> {
         .create_async()
         .await;
 
-    poller.query_all_origins().await?;
+    poller.run().await?;
 
     mock.assert_async().await;
 
@@ -131,7 +132,7 @@ async fn can_record_client_failures(pool: PgPool) -> Result<()> {
         .create_async()
         .await;
 
-    poller.query_all_origins().await?;
+    poller.run().await?;
 
     mock.assert_async().await;
 
@@ -152,7 +153,7 @@ async fn can_record_query_failures(pool: PgPool) -> Result<()> {
     let origin_uid = Uuid::new_v4();
     crate::persistence::insert_origin(&pool, origin_uid, uri).await?;
 
-    poller.query_all_origins().await?;
+    poller.run().await?;
 
     let failure_reason = fetch_latest_query_failure(&pool, uri).await?;
 
@@ -176,7 +177,7 @@ async fn can_route_alerts_to_clients(pool: PgPool) -> Result<()> {
 
     // Make 3 queries, all of which fail
     for _ in 0..3 {
-        poller.query_all_origins().await?;
+        poller.run().await?;
     }
 
     let map = poller.notifier.sent_messages.read().await;
@@ -203,11 +204,11 @@ async fn alerts_are_not_constantly_routed(pool: PgPool) -> Result<()> {
 
     // Make 3 queries, all of which fail to trigger an alert
     for _ in 0..3 {
-        poller.query_all_origins().await?;
+        poller.run().await?;
     }
 
     // Trigger another query which fails
-    poller.query_all_origins().await?;
+    poller.run().await?;
 
     // Check we only sent a single message
     let map = poller.notifier.sent_messages.read().await;
@@ -230,14 +231,14 @@ async fn alerts_can_cooldown_after_firing(pool: PgPool) -> Result<()> {
 
     // Make 3 queries, all of which fail to trigger an alert
     for _ in 0..3 {
-        poller.query_all_origins().await?;
+        poller.run().await?;
     }
 
     // Wait for the cooldown to expire, with a small buffer
     sleep(Duration::milliseconds(150)).await?;
 
     // Trigger another query which fails
-    poller.query_all_origins().await?;
+    poller.run().await?;
 
     // Check we sent 2 messages since the cooldown had passed
     let map = poller.notifier.sent_messages.read().await;
@@ -268,7 +269,7 @@ async fn certificate_expiry_triggers_notification(pool: PgPool) -> Result<()> {
         .create_async()
         .await;
 
-    poller.query_all_origins().await?;
+    poller.run().await?;
 
     mock.assert_async().await;
 
@@ -305,7 +306,7 @@ async fn certificate_expiry_does_not_trigger_when_far_away(pool: PgPool) -> Resu
         .create_async()
         .await;
 
-    poller.query_all_origins().await?;
+    poller.run().await?;
 
     mock.assert_async().await;
 
@@ -336,7 +337,7 @@ async fn notification_types_have_independent_cooldowns(pool: PgPool) -> Result<(
 
     // Trigger 3 queries - all will fail due to bad request, but should also trigger cert alert
     for _ in 0..3 {
-        poller.query_all_origins().await?;
+        poller.run().await?;
     }
 
     // Check that both notifications were sent
@@ -388,7 +389,7 @@ async fn renewed_certificate_does_not_trigger_notification(pool: PgPool) -> Resu
         .create_async()
         .await;
 
-    poller.query_all_origins().await?;
+    poller.run().await?;
 
     mock.assert_async().await;
 
@@ -424,10 +425,10 @@ async fn certificate_notifications_respect_cooldown(pool: PgPool) -> Result<()> 
         .await;
 
     // Trigger first certificate notification
-    poller.query_all_origins().await?;
+    poller.run().await?;
 
     // Should not send another notification immediately
-    poller.query_all_origins().await?;
+    poller.run().await?;
 
     // Check only 1 notification sent
     {
@@ -439,7 +440,7 @@ async fn certificate_notifications_respect_cooldown(pool: PgPool) -> Result<()> 
     sleep(Duration::milliseconds(150)).await?;
 
     // Should send another notification after cooldown
-    poller.query_all_origins().await?;
+    poller.run().await?;
 
     mock.assert_async().await;
 


### PR DESCRIPTION
Writing jobs should be easy, you just want to define how frequently it should run and what it should do on each iteration.

This change:
* Introduces a `Job` trait that defines these parameters
* Updates `RecurringJob` to just wrap this trait to implement `GracefulTask`
* Updates the existing jobs to use it
