### PR TITLE
feat: set password directly

### DIFF
--- a/.github/workflows/terraform-apply.yaml
+++ b/.github/workflows/terraform-apply.yaml
@@ -11,6 +11,7 @@ env:
   AWS_REGION: "eu-west-1"
   AWS_ACCESS_KEY_ID: ${{ secrets.DEPLOYER_ACCESS_KEY }}
   AWS_SECRET_ACCESS_KEY: ${{ secrets.DEPLOYER_SECRET_ACCESS_KEY }}
+  TF_VAR_db_password: ${{ secrets.DB_PASSWORD }}
 
 jobs:
   terraform:

--- a/.github/workflows/terraform-plan.yaml
+++ b/.github/workflows/terraform-plan.yaml
@@ -11,6 +11,7 @@ env:
   AWS_REGION: "eu-west-1"
   AWS_ACCESS_KEY_ID: ${{ secrets.DEPLOYER_ACCESS_KEY }}
   AWS_SECRET_ACCESS_KEY: ${{ secrets.DEPLOYER_SECRET_ACCESS_KEY }}
+  TF_VAR_db_password: ${{ secrets.DB_PASSWORD }}
 
 jobs:
   terraform:

--- a/infrastructure/terraform/aws.tf
+++ b/infrastructure/terraform/aws.tf
@@ -458,6 +458,7 @@ module "rds_postgres" {
   engine_version    = "15"
   instance_class    = "db.t4g.micro"
   allocated_storage = 20
+  password          = var.db_password
 }
 
 resource "aws_route53_record" "rds_postgres" {

--- a/infrastructure/terraform/modules/rds-postgres/main.tf
+++ b/infrastructure/terraform/modules/rds-postgres/main.tf
@@ -32,7 +32,7 @@ resource "aws_db_instance" "this" {
 
   db_name                     = "postgres"
   username                    = "postgres"
-  manage_master_user_password = true
+  password = var.password
 
   db_subnet_group_name   = aws_db_subnet_group.this.name
   vpc_security_group_ids = [aws_security_group.this.id]

--- a/infrastructure/terraform/modules/rds-postgres/variables.tf
+++ b/infrastructure/terraform/modules/rds-postgres/variables.tf
@@ -40,3 +40,9 @@ variable "allocated_storage" {
   default     = 20
   description = "Storage allocation in GiB (minimum 20 for RDS)"
 }
+
+variable "password" {
+  type        = string
+  sensitive   = true
+  description = "Master password for the postgres user"
+}

--- a/infrastructure/terraform/scripts/apply.sh
+++ b/infrastructure/terraform/scripts/apply.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+source "$(dirname "$0")/secrets.sh"
+cd "$(dirname "$0")/.."
+
+terraform apply -input=false "$@"

--- a/infrastructure/terraform/scripts/plan.sh
+++ b/infrastructure/terraform/scripts/plan.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+source "$(dirname "$0")/secrets.sh"
+cd "$(dirname "$0")/.."
+
+terraform plan -no-color -input=false "$@"

--- a/infrastructure/terraform/scripts/secrets.sh
+++ b/infrastructure/terraform/scripts/secrets.sh
@@ -1,0 +1,4 @@
+echo "Fetching secrets from 1Password..."
+export TF_VAR_db_password
+TF_VAR_db_password=$(op item get --vault Private "Database Passwords" --fields "postgres" --reveal)
+echo "Secrets fetched successfully."

--- a/infrastructure/terraform/variables.tf
+++ b/infrastructure/terraform/variables.tf
@@ -1,0 +1,5 @@
+variable "db_password" {
+  type        = string
+  sensitive   = true
+  description = "Master password for the RDS postgres instance"
+}


### PR DESCRIPTION
The database password is currently managed by AWS Secrets Manager which keeps rotating it (and changing it on the instance). This means applications keep failing to start up.

This change:
* Updates it to be provided by a secret
* Adds scripts for local plan and apply commands that grabs it from 1Password
