### PR TITLE
feat: hide seatings before introduction

### DIFF
--- a/apps/events/local-config.yaml
+++ b/apps/events/local-config.yaml
@@ -2,6 +2,9 @@ server:
   host: 0.0.0.0
   port: 3333
 
+application:
+  seating_cutoff: 2026-04-23
+
 telemetry:
   enabled: false
   endpoint: "http://localhost:4318/v1/traces"

--- a/apps/events/src/config.rs
+++ b/apps/events/src/config.rs
@@ -1,14 +1,22 @@
 use std::net::Ipv4Addr;
 
+use chrono::NaiveDate;
 use serde::Deserialize;
 
 #[derive(Deserialize)]
 pub struct Configuration {
-    pub server: ServerConfig,
+    pub server: ServerConfiguration,
+    pub application: ApplicationConfiguration,
 }
 
 #[derive(Deserialize)]
-pub struct ServerConfig {
+pub struct ServerConfiguration {
     pub host: Ipv4Addr,
     pub port: u16,
+}
+
+#[derive(Copy, Clone, Debug, Deserialize)]
+pub struct ApplicationConfiguration {
+    /// The date after which seating events should be considered for display in the history.
+    pub seating_cutoff: NaiveDate,
 }

--- a/apps/events/src/main.rs
+++ b/apps/events/src/main.rs
@@ -21,7 +21,7 @@ async fn main() -> Result<()> {
 
     let addr = SocketAddrV4::new(config.server.host, config.server.port);
     let listener = TcpListener::bind(addr).await?;
-    let server = crate::server::build(template_engine, pool, listener);
+    let server = crate::server::build((*config).application, template_engine, pool, listener);
 
     ShutdownCoordinator::new().with_task(server).run().await?;
 

--- a/apps/events/src/server.rs
+++ b/apps/events/src/server.rs
@@ -14,6 +14,7 @@ use serde::{Deserialize, Deserializer};
 use sqlx::PgPool;
 use tokio::net::TcpListener;
 
+use crate::config::ApplicationConfiguration;
 use crate::error::ServerResult;
 use crate::persistence::EventType;
 use crate::templates::{HistoryContext, IndexContext};
@@ -75,12 +76,19 @@ impl EventForm {
 
 #[derive(Clone)]
 struct ApplicationState {
+    configuration: ApplicationConfiguration,
     template_engine: TemplateEngine,
     pool: PgPool,
 }
 
-pub fn build(template_engine: TemplateEngine, pool: PgPool, listener: TcpListener) -> Server {
+pub fn build(
+    configuration: ApplicationConfiguration,
+    template_engine: TemplateEngine,
+    pool: PgPool,
+    listener: TcpListener,
+) -> Server {
     let state = ApplicationState {
+        configuration,
         template_engine,
         pool,
     };
@@ -120,13 +128,14 @@ async fn index(
 #[tracing::instrument(skip(template_engine, pool))]
 async fn history(
     State(ApplicationState {
+        configuration,
         template_engine,
         pool,
         ..
     }): State<ApplicationState>,
 ) -> ServerResult<RenderedTemplate> {
     let days = crate::persistence::get_history(&pool, Utc::now()).await?;
-    let context = HistoryContext::from(days);
+    let context = HistoryContext::from(days, configuration.seating_cutoff);
     let rendered = template_engine.render_serialized("history.tera.html", &context)?;
 
     Ok(rendered)

--- a/apps/events/src/templates.rs
+++ b/apps/events/src/templates.rs
@@ -1,3 +1,4 @@
+use chrono::NaiveDate;
 use serde::Serialize;
 
 use crate::persistence::{DailyStats, DayHistory, EventType};
@@ -59,8 +60,13 @@ pub struct HistoryEntry {
     pub wear_time_display: String,
     pub out_time_display: String,
     pub is_on_track: bool,
-    pub seating_count: i32,
-    pub seating_target: i32,
+    pub seatings: Option<SeatingInformation>,
+}
+
+#[derive(Serialize)]
+pub struct SeatingInformation {
+    pub count: i32,
+    pub target: i32,
 }
 
 #[derive(Serialize)]
@@ -68,17 +74,27 @@ pub struct HistoryContext {
     pub entries: Vec<HistoryEntry>,
 }
 
-impl From<Vec<DayHistory>> for HistoryContext {
-    fn from(days: Vec<DayHistory>) -> Self {
+impl HistoryContext {
+    pub fn from(days: Vec<DayHistory>, cutoff: NaiveDate) -> Self {
         let entries = days
             .into_iter()
-            .map(|day| HistoryEntry {
-                date: day.date.format("%a, %d %b %Y").to_string(),
-                wear_time_display: format_minutes(day.wear_minutes),
-                out_time_display: format_minutes(day.out_minutes),
-                is_on_track: day.is_on_track,
-                seating_count: day.seating_count,
-                seating_target: 2,
+            .map(|day| {
+                let seatings = if day.date >= cutoff {
+                    Some(SeatingInformation {
+                        count: day.seating_count,
+                        target: 2,
+                    })
+                } else {
+                    None
+                };
+
+                HistoryEntry {
+                    date: day.date.format("%a, %d %b %Y").to_string(),
+                    wear_time_display: format_minutes(day.wear_minutes),
+                    out_time_display: format_minutes(day.out_minutes),
+                    is_on_track: day.is_on_track,
+                    seatings,
+                }
             })
             .collect();
 
@@ -93,5 +109,41 @@ fn format_minutes(minutes: i64) -> String {
         format!("{}h {}m", hours, mins)
     } else {
         format!("{}m", mins)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use chrono::NaiveDate;
+
+    use crate::persistence::DayHistory;
+    use crate::templates::HistoryContext;
+
+    #[test]
+    fn cutoff_applies_to_history_entries() {
+        let cutoff = NaiveDate::from_ymd_opt(2024, 6, 1).unwrap();
+
+        let context = HistoryContext::from(
+            vec![
+                DayHistory {
+                    date: NaiveDate::from_ymd_opt(2024, 6, 2).unwrap(),
+                    wear_minutes: 480,
+                    out_minutes: 120,
+                    is_on_track: true,
+                    seating_count: 1,
+                },
+                DayHistory {
+                    date: NaiveDate::from_ymd_opt(2024, 5, 31).unwrap(),
+                    wear_minutes: 450,
+                    out_minutes: 150,
+                    is_on_track: false,
+                    seating_count: 0,
+                },
+            ],
+            cutoff,
+        );
+
+        assert!(context.entries[0].seatings.is_some());
+        assert!(context.entries[1].seatings.is_none());
     }
 }

--- a/apps/events/templates/history.tera.html
+++ b/apps/events/templates/history.tera.html
@@ -74,14 +74,16 @@
                             <p class="text-gray-400 mb-0.5">Out time</p>
                             <p class="font-semibold text-dark-text">{{ entry.out_time_display }}</p>
                         </div>
+						{% if entry.seatings %}
                         <div>
-                            <p class="text-gray-400 mb-0.5">Seating</p>
-                            {% if entry.seating_count >= entry.seating_target %}
-                            <p class="font-semibold text-green-400">{{ entry.seating_count }} / {{ entry.seating_target }}</p>
+                            <p class="text-gray-400 mb-0.5">Seatings</p>
+                            {% if entry.seatings.count >= entry.seatings.target %}
+                            <p class="font-semibold text-green-400">{{ entry.seatings.count }} / {{ entry.seatings.target }}</p>
                             {% else %}
-                            <p class="font-semibold text-red-400">{{ entry.seating_count }} / {{ entry.seating_target }}</p>
+                            <p class="font-semibold text-red-400">{{ entry.seatings.count }} / {{ entry.seatings.target }}</p>
                             {% endif %}
                         </div>
+						{% endif %}
                     </div>
                 </div>
                 {% endfor %}

--- a/infrastructure/configuration/events/config.yaml
+++ b/infrastructure/configuration/events/config.yaml
@@ -2,6 +2,9 @@ server:
   host: 0.0.0.0
   port: 3333
 
+application:
+  seating_cutoff: 2026-04-15
+
 database:
   host: rds.mesh.internal
   port: 5432


### PR DESCRIPTION
Tracking of seatings was only introduced on the 15th of April and as such there is no data before that. Instead of showing that it was 0/2 every day beforehand, just avoid showing it in the UI.

This change:
* Adds a configuration property to decide when the feature was launched
* Updates the code to only show the information after that
* Adds a test to make sure it works
