### PR TITLE
feat: upgrade database instance

### DIFF
--- a/infrastructure/terraform/aws.tf
+++ b/infrastructure/terraform/aws.tf
@@ -455,7 +455,7 @@ module "rds_postgres" {
 
   allowed_security_group_ids = [module.primary.security_group_id]
 
-  engine_version    = "15"
+  engine_version    = "18.3"
   instance_class    = "db.t4g.micro"
   allocated_storage = 20
   password          = var.db_password


### PR DESCRIPTION
This database instance is currently running 15.14 which is rather old, and AWS has emailed saying they're going to do a minor version upgrade to 15.17 in the coming days.

Instead, upgrade it straight to the latest version (which the CLI says is a valid upgrade path).

This change:
* Updates the instance to be running PostgreSQL 18.3
