### PR TITLE
feat: allow major version upgrades

### DIFF
--- a/infrastructure/terraform/aws.tf
+++ b/infrastructure/terraform/aws.tf
@@ -459,6 +459,8 @@ module "rds_postgres" {
   instance_class    = "db.t4g.micro"
   allocated_storage = 20
   password          = var.db_password
+
+  allow_major_version_upgrade = true
 }
 
 resource "aws_route53_record" "rds_postgres" {

--- a/infrastructure/terraform/modules/rds-postgres/main.tf
+++ b/infrastructure/terraform/modules/rds-postgres/main.tf
@@ -44,4 +44,6 @@ resource "aws_db_instance" "this" {
   backup_retention_period   = 1
   skip_final_snapshot       = false
   final_snapshot_identifier = format("%s-final-snapshot", var.name)
+
+  allow_major_version_upgrade = var.allow_major_version_upgrade
 }

--- a/infrastructure/terraform/modules/rds-postgres/variables.tf
+++ b/infrastructure/terraform/modules/rds-postgres/variables.tf
@@ -46,3 +46,9 @@ variable "password" {
   sensitive   = true
   description = "Master password for the postgres user"
 }
+
+variable "allow_major_version_upgrade" {
+  type        = bool
+  default     = false
+  description = "Whether major version upgrades are allowed"
+}


### PR DESCRIPTION
Major version upgrades are disabled by default and the current plan wants to go from 15 -> 18 so it needs to be enabled.

This change:
* Allows configuration of the flag and sets it to true
