### PR TITLE
feat: make changes apply immediately

### DIFF
--- a/infrastructure/terraform/aws.tf
+++ b/infrastructure/terraform/aws.tf
@@ -455,12 +455,13 @@ module "rds_postgres" {
 
   allowed_security_group_ids = [module.primary.security_group_id]
 
-  engine_version    = "18.3"
+  engine_version    = "15.14"
   instance_class    = "db.t4g.micro"
   allocated_storage = 20
   password          = var.db_password
 
   allow_major_version_upgrade = true
+  apply_immediately           = true
 }
 
 resource "aws_route53_record" "rds_postgres" {

--- a/infrastructure/terraform/modules/rds-postgres/main.tf
+++ b/infrastructure/terraform/modules/rds-postgres/main.tf
@@ -46,4 +46,5 @@ resource "aws_db_instance" "this" {
   final_snapshot_identifier = format("%s-final-snapshot", var.name)
 
   allow_major_version_upgrade = var.allow_major_version_upgrade
+  apply_immediately           = var.apply_immediately
 }

--- a/infrastructure/terraform/modules/rds-postgres/variables.tf
+++ b/infrastructure/terraform/modules/rds-postgres/variables.tf
@@ -52,3 +52,9 @@ variable "allow_major_version_upgrade" {
   default     = false
   description = "Whether major version upgrades are allowed"
 }
+
+variable "apply_immediately" {
+  type        = bool
+  default     = true
+  description = "Whether to apply changes immediately or during the next maintenance window"
+}


### PR DESCRIPTION
The version upgrade is staged for the next maintenance window, but it would be good to just change it now.

This change:
* Sets the `apply_immediately` flag
* Rolls back the version upgrade so it's a no-op and the bump to 18.3 can be done in the next PR
