### PR TITLE
feat: send renewal notifications

### DIFF
--- a/apps/Cargo.lock
+++ b/apps/Cargo.lock
@@ -978,6 +978,7 @@ dependencies = [
  "foundation-templating",
  "foundation-uid",
  "instant-acme",
+ "reqwest 0.13.3",
  "rustls 0.23.37",
  "serde",
  "sqlx",
@@ -1802,7 +1803,7 @@ dependencies = [
  "axum",
  "color-eyre",
  "foundation-shutdown",
- "reqwest",
+ "reqwest 0.12.28",
  "tokio",
  "tower-http 0.6.8",
  "tower-layer",
@@ -3445,7 +3446,7 @@ dependencies = [
  "bytes",
  "http 1.4.0",
  "opentelemetry",
- "reqwest",
+ "reqwest 0.12.28",
 ]
 
 [[package]]
@@ -3460,7 +3461,7 @@ dependencies = [
  "opentelemetry-proto",
  "opentelemetry_sdk",
  "prost",
- "reqwest",
+ "reqwest 0.12.28",
  "thiserror 2.0.18",
  "tracing",
 ]
@@ -3996,6 +3997,7 @@ version = "0.11.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1906b49b0c3bc04b5fe5d86a77925ae6524a19b816ae38ce1e426255f1d8a31"
 dependencies = [
+ "aws-lc-rs",
  "bytes",
  "getrandom 0.3.4",
  "lru-slab",
@@ -4232,6 +4234,41 @@ dependencies = [
  "wasm-bindgen-futures",
  "web-sys",
  "webpki-roots 1.0.6",
+]
+
+[[package]]
+name = "reqwest"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62e0021ea2c22aed41653bc7e1419abb2c97e038ff2c33d0e1309e49a97deec0"
+dependencies = [
+ "base64",
+ "bytes",
+ "futures-core",
+ "http 1.4.0",
+ "http-body 1.0.1",
+ "http-body-util",
+ "hyper 1.8.1",
+ "hyper-rustls 0.27.7",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "percent-encoding",
+ "pin-project-lite",
+ "quinn",
+ "rustls 0.23.37",
+ "rustls-pki-types",
+ "rustls-platform-verifier",
+ "sync_wrapper",
+ "tokio",
+ "tokio-rustls 0.26.4",
+ "tower 0.5.3",
+ "tower-http 0.6.8",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
 ]
 
 [[package]]
@@ -5809,7 +5846,7 @@ dependencies = [
  "foundation-templating",
  "humantime",
  "mockito",
- "reqwest",
+ "reqwest 0.12.28",
  "serde",
  "sqlx",
  "tokio",

--- a/apps/certmanager/Cargo.toml
+++ b/apps/certmanager/Cargo.toml
@@ -17,6 +17,7 @@ foundation-shutdown = { version = "0.1.0", path = "../foundation/shutdown" }
 foundation-templating = { version = "0.1.0", path = "../foundation/templating" }
 foundation-uid = { version = "0.1.0", path = "../foundation/uid" }
 instant-acme = "0.8.5"
+reqwest = { version = "0.13.3", default-features = false, features = ["rustls"] }
 rustls = "0.23.37"
 serde = { workspace = true, features = ["derive"] }
 sqlx = { version = "0.8.2", default-features = false, features = ["chrono", "macros", "migrate", "postgres", "runtime-tokio-rustls", "uuid"] }

--- a/apps/certmanager/src/configuration.rs
+++ b/apps/certmanager/src/configuration.rs
@@ -10,6 +10,13 @@ pub struct Configuration {
     pub server: ServerConfiguration,
     pub storage: StorageConfiguration,
     pub acme: AcmeConfiguration,
+    pub notify: NotifyConfiguration,
+}
+
+#[derive(Clone, Debug, Deserialize)]
+pub struct NotifyConfiguration {
+    pub url: String,
+    pub path: String,
 }
 
 #[derive(Clone, Debug, Deserialize)]

--- a/apps/certmanager/src/main.rs
+++ b/apps/certmanager/src/main.rs
@@ -37,8 +37,15 @@ async fn main() -> Result<()> {
     let acme_client = AcmeClient::new(config.acme.environment, &config.acme.contact).await?;
     let dns_client = DnsClient::new(route53_client.clone());
     let cert_store = CertificateStore::new(s3_client.clone(), config.storage.clone());
+    let http_client = reqwest::Client::new();
 
-    let renewer = Renewer::new(acme_client.clone(), dns_client.clone(), cert_store.clone());
+    let renewer = Renewer::new(
+        acme_client.clone(),
+        dns_client.clone(),
+        cert_store.clone(),
+        http_client,
+        config.notify.clone(),
+    );
     let watcher = Watcher::new(renewer.clone(), pool.clone());
 
     let template_engine = TemplateEngine::new()?;

--- a/apps/certmanager/src/renewal.rs
+++ b/apps/certmanager/src/renewal.rs
@@ -3,6 +3,7 @@ use sqlx::types::chrono::{DateTime, Utc};
 use x509_parser::pem::Pem;
 
 use crate::acme::AcmeClient;
+use crate::configuration::NotifyConfiguration;
 use crate::dns::DnsClient;
 use crate::storage::CertificateStore;
 
@@ -11,6 +12,8 @@ pub struct Renewer {
     acme_client: AcmeClient,
     dns_client: DnsClient,
     cert_store: CertificateStore,
+    http_client: reqwest::Client,
+    notify: NotifyConfiguration,
 }
 
 impl Renewer {
@@ -18,11 +21,15 @@ impl Renewer {
         acme_client: AcmeClient,
         dns_client: DnsClient,
         cert_store: CertificateStore,
+        http_client: reqwest::Client,
+        notify: NotifyConfiguration,
     ) -> Self {
         Self {
             acme_client,
             dns_client,
             cert_store,
+            http_client,
+            notify,
         }
     }
 
@@ -39,6 +46,20 @@ impl Renewer {
         self.cert_store
             .put(domain, &private_key, &cert_chain)
             .await?;
+
+        let target = format!("{}{}", self.notify.url, self.notify.path);
+
+        match self.http_client.put(&target).send().await {
+            Ok(res) if res.status().is_success() => {
+                tracing::info!("notified f2 to reload certificates");
+            }
+            Ok(res) => {
+                tracing::warn!(status = %res.status(), "f2 certificate reload returned non-success status");
+            }
+            Err(e) => {
+                tracing::warn!(error = %e, "failed to notify f2 to reload certificates");
+            }
+        }
 
         let expiry = extract_certificate_expiry(cert_chain.as_bytes())?;
 


### PR DESCRIPTION
`f2` supports being notified about certificate renewals so that it can pull in the new ones and start serving them.

This change:
* Updates `certmanager` to call this endpoint after writing to S3
