### PR TITLE
feat: handle changing timezones

### DIFF
--- a/apps/Cargo.lock
+++ b/apps/Cargo.lock
@@ -1031,6 +1031,7 @@ dependencies = [
  "chrono",
  "chrono-tz-build",
  "phf 0.11.3",
+ "serde",
 ]
 
 [[package]]

--- a/apps/events/Cargo.toml
+++ b/apps/events/Cargo.toml
@@ -10,7 +10,7 @@ path = "src/main.rs"
 [dependencies]
 axum.workspace = true
 chrono = { version = "0.4.38", default-features = false, features = ["now", "serde"] }
-chrono-tz = "0.9.0"
+chrono-tz = { version = "0.9.0", features = ["serde"] }
 color-eyre = "0.6.3"
 foundation-http-server = { version = "0.1.0", path = "../foundation/http-server" }
 foundation-init = { version = "0.1.0", path = "../foundation/init", features = ["database"] }

--- a/apps/events/local-config.yaml
+++ b/apps/events/local-config.yaml
@@ -4,6 +4,7 @@ server:
 
 application:
   seating_cutoff: 2026-04-23
+  timezone: Europe/London
 
 telemetry:
   enabled: false

--- a/apps/events/src/config.rs
+++ b/apps/events/src/config.rs
@@ -1,6 +1,7 @@
 use std::net::Ipv4Addr;
 
 use chrono::NaiveDate;
+use chrono_tz::Tz;
 use serde::Deserialize;
 
 #[derive(Deserialize)]
@@ -19,4 +20,6 @@ pub struct ServerConfiguration {
 pub struct ApplicationConfiguration {
     /// The date after which seating events should be considered for display in the history.
     pub seating_cutoff: NaiveDate,
+    /// The IANA timezone of the user, used to compute day boundaries (e.g. "Europe/London").
+    pub timezone: Tz,
 }

--- a/apps/events/src/persistence.rs
+++ b/apps/events/src/persistence.rs
@@ -1,4 +1,5 @@
-use chrono::{DateTime, Duration, NaiveDate, Utc};
+use chrono::{DateTime, NaiveDate, Utc};
+use chrono_tz::Tz;
 use color_eyre::eyre::{Result, eyre};
 use itertools::Itertools;
 use sqlx::PgPool;
@@ -162,7 +163,7 @@ pub struct DayHistory {
 }
 
 #[tracing::instrument(skip(pool))]
-pub async fn get_history(pool: &PgPool, now: DateTime<Utc>) -> Result<Vec<DayHistory>> {
+pub async fn get_history(pool: &PgPool, now: DateTime<Utc>, tz: Tz) -> Result<Vec<DayHistory>> {
     let all_events = sqlx::query!(
         r#"
             SELECT ret.name as event_type, re.occurred_at
@@ -183,8 +184,8 @@ pub async fn get_history(pool: &PgPool, now: DateTime<Utc>) -> Result<Vec<DayHis
             .fetch_all(pool)
             .await?;
 
-    let first_date = all_events[0].occurred_at.date_naive();
-    let today_date = now.date_naive();
+    let first_date = all_events[0].occurred_at.with_timezone(&tz).date_naive();
+    let today_date = now.with_timezone(&tz).date_naive();
 
     let mut results = Vec::new();
     let mut carry_inserted = false;
@@ -193,8 +194,22 @@ pub async fn get_history(pool: &PgPool, now: DateTime<Utc>) -> Result<Vec<DayHis
     let mut day = first_date;
 
     while day <= today_date {
-        let day_start = day.and_hms_opt(0, 0, 0).unwrap().and_utc();
-        let day_end = day_start + Duration::hours(24);
+        let day_start = day
+            .and_hms_opt(0, 0, 0)
+            .unwrap()
+            .and_local_timezone(tz)
+            .earliest()
+            .unwrap()
+            .to_utc();
+        let day_end = day
+            .succ_opt()
+            .unwrap()
+            .and_hms_opt(0, 0, 0)
+            .unwrap()
+            .and_local_timezone(tz)
+            .earliest()
+            .unwrap()
+            .to_utc();
         let effective_end = if day == today_date { now } else { day_end };
 
         let mut wear_minutes: i64 = 0;
@@ -505,7 +520,7 @@ mod tests {
     #[sqlx::test]
     async fn no_events_returns_empty_history(pool: PgPool) -> Result<()> {
         let now = Utc.with_ymd_and_hms(2026, 1, 1, 12, 0, 0).unwrap();
-        let history = get_history(&pool, now).await?;
+        let history = get_history(&pool, now, chrono_tz::UTC).await?;
 
         assert!(history.is_empty());
 
@@ -531,7 +546,7 @@ mod tests {
 
         // now is day 2, so day 1 is a completed past day (effective_end = midnight)
         let now = Utc.with_ymd_and_hms(2026, 1, 2, 12, 0, 0).unwrap();
-        let history = get_history(&pool, now).await?;
+        let history = get_history(&pool, now, chrono_tz::UTC).await?;
 
         // history[0] = Jan 2 (today), history[1] = Jan 1 (past)
         assert_eq!(history[1].wear_minutes, 12 * 60);
@@ -571,7 +586,7 @@ mod tests {
         .await?;
 
         let now = Utc.with_ymd_and_hms(2026, 1, 2, 22, 0, 0).unwrap();
-        let history = get_history(&pool, now).await?;
+        let history = get_history(&pool, now, chrono_tz::UTC).await?;
 
         assert_eq!(history.len(), 2);
         assert_eq!(
@@ -601,7 +616,7 @@ mod tests {
         record_event(&pool, EventType::Removed, day2 + chrono::Duration::hours(8)).await?;
 
         let now = Utc.with_ymd_and_hms(2026, 1, 2, 12, 0, 0).unwrap();
-        let history = get_history(&pool, now).await?;
+        let history = get_history(&pool, now, chrono_tz::UTC).await?;
 
         assert_eq!(history.len(), 2);
         // Day 1: wore from 9pm to midnight = 3h
@@ -643,7 +658,7 @@ mod tests {
         .await?;
 
         let now = Utc.with_ymd_and_hms(2026, 1, 3, 22, 0, 0).unwrap();
-        let history = get_history(&pool, now).await?;
+        let history = get_history(&pool, now, chrono_tz::UTC).await?;
 
         assert_eq!(history.len(), 3);
         // history[0] = Jan 3, [1] = Jan 2, [2] = Jan 1
@@ -670,7 +685,7 @@ mod tests {
         .await?;
 
         let now = Utc.with_ymd_and_hms(2026, 1, 2, 12, 0, 0).unwrap();
-        let history = get_history(&pool, now).await?;
+        let history = get_history(&pool, now, chrono_tz::UTC).await?;
 
         assert!(history[1].is_on_track);
 
@@ -690,7 +705,7 @@ mod tests {
         .await?;
 
         let now = Utc.with_ymd_and_hms(2026, 1, 2, 12, 0, 0).unwrap();
-        let history = get_history(&pool, now).await?;
+        let history = get_history(&pool, now, chrono_tz::UTC).await?;
 
         assert!(!history[1].is_on_track);
 
@@ -761,7 +776,7 @@ mod tests {
         record_seating(&pool, day2 + chrono::Duration::hours(9)).await?;
 
         let now = Utc.with_ymd_and_hms(2026, 1, 2, 12, 0, 0).unwrap();
-        let history = get_history(&pool, now).await?;
+        let history = get_history(&pool, now, chrono_tz::UTC).await?;
 
         // history[0] = Jan 2, history[1] = Jan 1
         assert_eq!(history[1].seating_count, 2);

--- a/apps/events/src/server.rs
+++ b/apps/events/src/server.rs
@@ -1,11 +1,11 @@
 use axum::Router;
 use axum::body::Body;
 use axum::extract::{Form, State};
-use axum::http::StatusCode;
-use axum::http::header::LOCATION;
+use axum::http::header::{COOKIE, LOCATION};
+use axum::http::{HeaderMap, StatusCode};
 use axum::response::Response;
 use axum::routing::{get, post};
-use chrono::{DateTime, Local, NaiveDateTime, Utc};
+use chrono::{DateTime, NaiveDateTime, Utc};
 use chrono_tz::Tz;
 use color_eyre::eyre::{Result, eyre};
 use foundation_http_server::Server;
@@ -107,18 +107,25 @@ pub fn build(
 #[tracing::instrument(skip(template_engine, pool))]
 async fn index(
     State(ApplicationState {
+        configuration,
         template_engine,
         pool,
-        ..
     }): State<ApplicationState>,
+    headers: HeaderMap,
 ) -> ServerResult<RenderedTemplate> {
-    let today_start = Local::now()
+    let tz = timezone_from_cookie(&headers, configuration.timezone);
+    let now = Utc::now();
+    let today_start = now
+        .with_timezone(&tz)
         .date_naive()
         .and_hms_opt(0, 0, 0)
         .unwrap()
-        .and_utc();
+        .and_local_timezone(tz)
+        .earliest()
+        .unwrap()
+        .to_utc();
 
-    let stats = crate::persistence::get_daily_stats(&pool, today_start, Utc::now()).await?;
+    let stats = crate::persistence::get_daily_stats(&pool, today_start, now).await?;
     let context = IndexContext::from(stats);
     let rendered = template_engine.render_serialized("index.tera.html", &context)?;
 
@@ -133,8 +140,10 @@ async fn history(
         pool,
         ..
     }): State<ApplicationState>,
+    headers: HeaderMap,
 ) -> ServerResult<RenderedTemplate> {
-    let days = crate::persistence::get_history(&pool, Utc::now()).await?;
+    let tz = timezone_from_cookie(&headers, configuration.timezone);
+    let days = crate::persistence::get_history(&pool, Utc::now(), tz).await?;
     let context = HistoryContext::from(days, configuration.seating_cutoff);
     let rendered = template_engine.render_serialized("history.tera.html", &context)?;
 
@@ -169,6 +178,18 @@ async fn seating(
     crate::persistence::record_seating(&pool, form.into_utc()?).await?;
     tracing::info!("recorded seating");
     Ok(redirect("/")?)
+}
+
+fn timezone_from_cookie(headers: &HeaderMap, fallback: Tz) -> Tz {
+    headers
+        .get(COOKIE)
+        .and_then(|v| v.to_str().ok())
+        .and_then(|s| {
+            s.split(';')
+                .find_map(|part| part.trim().strip_prefix("tz="))
+        })
+        .and_then(|tz_str| tz_str.parse().ok())
+        .unwrap_or(fallback)
 }
 
 fn redirect(path: &'static str) -> Result<Response> {

--- a/apps/events/templates/history.tera.html
+++ b/apps/events/templates/history.tera.html
@@ -111,5 +111,11 @@
         {% endif %}
       </main>
     </div>
+    <script>
+      try {
+        var tz = Intl.DateTimeFormat().resolvedOptions().timeZone;
+        if (tz) document.cookie = "tz=" + tz + "; path=/; SameSite=Strict";
+      } catch (e) {}
+    </script>
   </body>
 </html>

--- a/apps/events/templates/index.tera.html
+++ b/apps/events/templates/index.tera.html
@@ -213,6 +213,9 @@
         try {
           tz = Intl.DateTimeFormat().resolvedOptions().timeZone || "";
         } catch (e) {}
+        if (tz) {
+          document.cookie = "tz=" + tz + "; path=/; SameSite=Strict";
+        }
         document.querySelectorAll("form").forEach(function (form) {
           form.addEventListener("submit", function () {
             var field = form.querySelector('input[name="timezone"]');


### PR DESCRIPTION
`events` doesn't currently handle timezones properly, as everything works in the server timezone (aside from the bits where the user is uploading a form).

This change:
* Adds a default timezone of `Europe/London`
* Adds a user cookie containing the timezone information for future requests
