### PR TITLE
feat: add metrics for DNS requests

### DIFF
--- a/apps/Cargo.lock
+++ b/apps/Cargo.lock
@@ -978,7 +978,7 @@ dependencies = [
  "foundation-templating",
  "foundation-uid",
  "instant-acme",
- "reqwest 0.13.3",
+ "reqwest",
  "rustls 0.23.37",
  "serde",
  "sqlx",
@@ -1458,6 +1458,10 @@ dependencies = [
  "hickory-resolver",
  "hickory-server",
  "moka",
+ "opentelemetry",
+ "opentelemetry-otlp",
+ "opentelemetry_sdk",
+ "reqwest",
  "rustls 0.23.37",
  "rustls-pemfile",
  "serde",
@@ -1770,7 +1774,7 @@ dependencies = [
  "axum",
  "color-eyre",
  "foundation-shutdown",
- "reqwest 0.13.3",
+ "reqwest",
  "tokio",
  "tower-http 0.6.8",
  "tower-layer",
@@ -3323,9 +3327,9 @@ dependencies = [
 
 [[package]]
 name = "opentelemetry"
-version = "0.30.0"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aaf416e4cb72756655126f7dd7bb0af49c674f4c1b9903e80c009e0c37e552e6"
+checksum = "b0142c63252a9e054e68a4c61a5778f7b14f576274d593f8ce883d191a099682"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -3337,22 +3341,22 @@ dependencies = [
 
 [[package]]
 name = "opentelemetry-http"
-version = "0.30.0"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50f6639e842a97dbea8886e3439710ae463120091e2e064518ba8e716e6ac36d"
+checksum = "5683015d09e2df236ef005b17f6f196f0d5f6313c4fa43a7b6a53b52776e4331"
 dependencies = [
  "async-trait",
  "bytes",
  "http 1.4.0",
  "opentelemetry",
- "reqwest 0.12.28",
+ "reqwest",
 ]
 
 [[package]]
 name = "opentelemetry-otlp"
-version = "0.30.0"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbee664a43e07615731afc539ca60c6d9f1a9425e25ca09c57bc36c87c55852b"
+checksum = "9966929966d17620d7c316c643ba62631826e10021409357772d5eea84f62c35"
 dependencies = [
  "http 1.4.0",
  "opentelemetry",
@@ -3360,37 +3364,37 @@ dependencies = [
  "opentelemetry-proto",
  "opentelemetry_sdk",
  "prost",
- "reqwest 0.12.28",
+ "reqwest",
  "thiserror 2.0.18",
- "tracing",
 ]
 
 [[package]]
 name = "opentelemetry-proto"
-version = "0.30.0"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e046fd7660710fe5a05e8748e70d9058dc15c94ba914e7c4faa7c728f0e8ddc"
+checksum = "56d658ba1faf63f7b9c492cfbe6e0ec365440a16132d3270c1065f7b33f1b638"
 dependencies = [
  "opentelemetry",
  "opentelemetry_sdk",
  "prost",
- "tonic",
 ]
 
 [[package]]
 name = "opentelemetry_sdk"
-version = "0.30.0"
+version = "0.32.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11f644aa9e5e31d11896e024305d7e3c98a88884d9f8919dbf37a9991bc47a4b"
+checksum = "9b59f80e1ac4d5ff7a2db8fb6c80badb7f0f3f858211fba08dd9aaec750894f9"
 dependencies = [
  "futures-channel",
  "futures-executor",
  "futures-util",
  "opentelemetry",
  "percent-encoding",
+ "portable-atomic",
  "rand 0.9.2",
- "serde_json",
  "thiserror 2.0.18",
+ "tokio",
+ "tokio-stream",
 ]
 
 [[package]]
@@ -3641,16 +3645,7 @@ version = "0.4.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3ef0f924a5ee7ea9cbcea77529dba45f8a9ba9f622419fe3386ca581a3ae9d5a"
 dependencies = [
- "pin-project-internal 0.4.30",
-]
-
-[[package]]
-name = "pin-project"
-version = "1.1.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1749c7ed4bcaf4c3d0a3efc28538844fb29bcdd7d2b67b2be7e20ba861ff517"
-dependencies = [
- "pin-project-internal 1.1.11",
+ "pin-project-internal",
 ]
 
 [[package]]
@@ -3662,17 +3657,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.109",
-]
-
-[[package]]
-name = "pin-project-internal"
-version = "1.1.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9b20ed30f105399776b9c883e68e536ef602a16ae6f596d2c473591d6ad64c6"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
 ]
 
 [[package]]
@@ -3820,9 +3804,9 @@ dependencies = [
 
 [[package]]
 name = "prost"
-version = "0.13.5"
+version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2796faa41db3ec313a31f7624d9286acf277b52de526150b7e69f3debf891ee5"
+checksum = "d2ea70524a2f82d518bce41317d0fae74151505651af45faf1ffbd6fd33f0568"
 dependencies = [
  "bytes",
  "prost-derive",
@@ -3830,9 +3814,9 @@ dependencies = [
 
 [[package]]
 name = "prost-derive"
-version = "0.13.5"
+version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
+checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
 dependencies = [
  "anyhow",
  "itertools",
@@ -4091,47 +4075,15 @@ checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "reqwest"
-version = "0.12.28"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
-dependencies = [
- "base64",
- "bytes",
- "futures-channel",
- "futures-core",
- "futures-util",
- "http 1.4.0",
- "http-body 1.0.1",
- "http-body-util",
- "hyper 1.8.1",
- "hyper-util",
- "js-sys",
- "log",
- "percent-encoding",
- "pin-project-lite",
- "serde",
- "serde_json",
- "serde_urlencoded",
- "sync_wrapper",
- "tokio",
- "tower 0.5.3",
- "tower-http 0.6.8",
- "tower-service",
- "url",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "web-sys",
-]
-
-[[package]]
-name = "reqwest"
 version = "0.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62e0021ea2c22aed41653bc7e1419abb2c97e038ff2c33d0e1309e49a97deec0"
 dependencies = [
  "base64",
  "bytes",
+ "futures-channel",
  "futures-core",
+ "futures-util",
  "http 1.4.0",
  "http-body 1.0.1",
  "http-body-util",
@@ -5357,27 +5309,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
-name = "tonic"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e581ba15a835f4d9ea06c55ab1bd4dce26fc53752c69a04aac00703bfb49ba9"
-dependencies = [
- "async-trait",
- "base64",
- "bytes",
- "http 1.4.0",
- "http-body 1.0.1",
- "http-body-util",
- "percent-encoding",
- "pin-project 1.1.11",
- "prost",
- "tokio-stream",
- "tower-layer",
- "tower-service",
- "tracing",
-]
-
-[[package]]
 name = "tower"
 version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5478,7 +5409,7 @@ checksum = "d1093c19826d33807c72511e68f73b4a0469a3f22c2bd5f7d5212178b4b89674"
 dependencies = [
  "futures-core",
  "futures-util",
- "pin-project 0.4.30",
+ "pin-project",
  "tower-service",
 ]
 
@@ -5538,14 +5469,12 @@ dependencies = [
 
 [[package]]
 name = "tracing-opentelemetry"
-version = "0.31.0"
+version = "0.33.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddcf5959f39507d0d04d6413119c04f33b623f4f951ebcbdddddfad2d0623a9c"
+checksum = "adbc64cba7137545b8044cb1fe9814f7aacf3c6b5f9b45be8bb5db538befdb26"
 dependencies = [
  "js-sys",
- "once_cell",
  "opentelemetry",
- "opentelemetry_sdk",
  "smallvec",
  "tracing",
  "tracing-core",
@@ -5676,7 +5605,7 @@ dependencies = [
  "foundation-templating",
  "humantime",
  "mockito",
- "reqwest 0.13.3",
+ "reqwest",
  "serde",
  "sqlx",
  "tokio",

--- a/apps/dns-server/Cargo.toml
+++ b/apps/dns-server/Cargo.toml
@@ -21,6 +21,10 @@ tokio = { version = "1.48.0", features = ["macros", "rt-multi-thread", "net", "t
 tracing.workspace = true
 rustls-pemfile = "2.0"
 rustls = { version = "0.23", features = ["ring"] }
+opentelemetry_sdk = { version = "0.32.0", features = ["metrics", "rt-tokio", "experimental_metrics_periodicreader_with_async_runtime"] }
+opentelemetry-otlp = { version = "0.32.0", features = ["metrics", "http-proto", "reqwest-client"] }
+opentelemetry = "0.32.0"
+reqwest.workspace = true
 
 [dev-dependencies]
 dns-mock-server = "0.1.6"

--- a/apps/dns-server/src/handler.rs
+++ b/apps/dns-server/src/handler.rs
@@ -1,6 +1,8 @@
 use hickory_proto::op::{Message, MessageType, OpCode, ResponseCode};
 use hickory_server::authority::MessageResponseBuilder;
 use hickory_server::server::{Request, RequestHandler, ResponseHandler, ResponseInfo};
+use opentelemetry::KeyValue;
+use opentelemetry::metrics::Counter;
 
 use crate::blocklist::BlocklistManager;
 use crate::cache::ResponseCache;
@@ -12,6 +14,8 @@ pub struct DnsRequestHandler {
     upstream: UpstreamResolver,
     blocklist: BlocklistManager,
     cache: ResponseCache,
+    requests: Counter<u64>,
+    responses: Counter<u64>,
 }
 
 impl DnsRequestHandler {
@@ -19,11 +23,15 @@ impl DnsRequestHandler {
         upstream: UpstreamResolver,
         blocklist: BlocklistManager,
         cache: ResponseCache,
+        requests: Counter<u64>,
+        responses: Counter<u64>,
     ) -> Self {
         Self {
             upstream,
             blocklist,
             cache,
+            requests,
+            responses,
         }
     }
 }
@@ -35,6 +43,8 @@ impl RequestHandler for DnsRequestHandler {
         request: &Request,
         mut response_handle: R,
     ) -> ResponseInfo {
+        self.requests.add(1, &[]);
+
         // Get request info to extract the query
         let request_info = match request.request_info() {
             Ok(info) => info,
@@ -71,6 +81,9 @@ impl RequestHandler for DnsRequestHandler {
                 "blocked domain query"
             );
 
+            self.responses
+                .add(1, &[KeyValue::new("type", "explicit-block")]);
+
             let response = MessageResponseBuilder::from_message_request(request)
                 .error_msg(&request.header().clone(), ResponseCode::Refused);
 
@@ -93,6 +106,9 @@ impl RequestHandler for DnsRequestHandler {
                 src = %request.src(),
                 "returning cached response"
             );
+
+            self.responses.add(1, &[KeyValue::new("type", "cache-hit")]);
+
             // Build response from cached message with correct ID
             let mut header = *cached_response.header();
             header.set_id(request.id()); // Use current request ID, not cached ID
@@ -130,6 +146,8 @@ impl RequestHandler for DnsRequestHandler {
                     "upstream resolution successful"
                 );
 
+                self.responses.add(1, &[KeyValue::new("type", "upstream")]);
+
                 // Cache the response with TTL from DNS records
                 let ttl = ResponseCache::extract_ttl(&response);
                 self.cache.insert(&cache_key, response.clone(), ttl).await;
@@ -138,6 +156,10 @@ impl RequestHandler for DnsRequestHandler {
             }
             Err(e) => {
                 tracing::warn!(error = ?e, src = %request.src(), "upstream resolution failed");
+
+                self.responses
+                    .add(1, &[KeyValue::new("type", "upstream-error")]);
+
                 // Build SERVFAIL response
                 let mut error_msg = Message::new();
                 error_msg.set_id(request_message.id());

--- a/apps/dns-server/src/main.rs
+++ b/apps/dns-server/src/main.rs
@@ -1,6 +1,13 @@
+use std::time::Duration;
+
 use color_eyre::eyre::Result;
 use foundation_recurring_job::RecurringJob;
 use foundation_shutdown::ShutdownCoordinator;
+use opentelemetry_otlp::{MetricExporter, WithExportConfig, WithHttpConfig};
+use opentelemetry_sdk::metrics::SdkMeterProvider;
+use opentelemetry_sdk::metrics::periodic_reader_with_async_runtime::PeriodicReader;
+use opentelemetry_sdk::runtime;
+use reqwest::Client;
 
 mod blocklist;
 mod cache;
@@ -27,6 +34,19 @@ async fn main() -> Result<()> {
         "dns server initialized"
     );
 
+    let exporter = MetricExporter::builder()
+        .with_http()
+        .with_http_client(Client::new())
+        .with_endpoint("http://localhost:9090/api/v1/otlp/v1/metrics")
+        .build()?;
+
+    let reader = PeriodicReader::builder(exporter, runtime::Tokio)
+        .with_interval(Duration::from_secs(30))
+        .build();
+    let provider = SdkMeterProvider::builder().with_reader(reader).build();
+
+    opentelemetry::global::set_meter_provider(provider);
+
     let blocklist = BlocklistManager::new(config.blocklist.clone()).await?;
     let upstream = UpstreamResolver::new(&config.upstream).await?;
     let cache = ResponseCache::new(&config.cache);
@@ -35,12 +55,26 @@ async fn main() -> Result<()> {
 
     let certificate_resolver = CertificateResolver::new(tls_config.clone()).await?;
 
+    let meter = opentelemetry::global::meter("dns-server");
+
+    let requests = meter
+        .u64_counter("dns_requests_total")
+        .with_description("Total number of DNS requests received")
+        .build();
+
+    let responses = meter
+        .u64_counter("dns_responses_total")
+        .with_description("Total number of DNS responses sent")
+        .build();
+
     let dns_server = DnsServer::new(
         upstream,
         blocklist.clone(),
         cache,
         tls_config,
         certificate_resolver.clone(),
+        requests,
+        responses,
     )
     .await?;
 

--- a/apps/dns-server/src/server.rs
+++ b/apps/dns-server/src/server.rs
@@ -5,6 +5,7 @@ use std::time::Duration;
 use color_eyre::eyre::Result;
 use foundation_shutdown::{CancellationToken, GracefulTask};
 use hickory_server::ServerFuture;
+use opentelemetry::metrics::Counter;
 use tokio::net::TcpListener;
 
 use crate::blocklist::BlocklistManager;
@@ -26,8 +27,10 @@ impl DnsServer {
         cache: ResponseCache,
         config: &TlsConfig,
         certificate_resolver: CertificateResolver,
+        requests: Counter<u64>,
+        responses: Counter<u64>,
     ) -> Result<Self> {
-        let handler = DnsRequestHandler::new(upstream, blocklist, cache);
+        let handler = DnsRequestHandler::new(upstream, blocklist, cache, requests, responses);
         let mut server_future = ServerFuture::new(handler);
 
         register_tls_listener(&mut server_future, config, certificate_resolver).await?;

--- a/apps/foundation/telemetry/Cargo.toml
+++ b/apps/foundation/telemetry/Cargo.toml
@@ -5,10 +5,10 @@ edition = "2024"
 
 [dependencies]
 color-eyre = { version = "0.6.5", default-features = false }
-opentelemetry = "0.30.0"
-opentelemetry-otlp = "0.30.0"
-opentelemetry_sdk = "0.30.0"
+opentelemetry = "0.32.0"
+opentelemetry-otlp = "0.32.0"
+opentelemetry_sdk = "0.32.0"
 serde = { workspace = true, features = ["derive"] }
 tracing-core = "0.1.34"
-tracing-opentelemetry = "0.31.0"
+tracing-opentelemetry = "0.33.0"
 tracing-subscriber = "0.3.19"


### PR DESCRIPTION
Since the `dns-server` typically has SSH access disabled, it's difficult to tell that it is working correctly. It would be good to start plumbing metrics through all the services to have an overview of their state, so `dns-server` seems like a good place to start.

This change:
* Bumps the existing `opentelemetry` dependencies
* Adds some metric handling to `dns-server`
