### PR TITLE
feat: allow metrics to be configured

### DIFF
--- a/apps/dns-server/resources/sample-config.yaml
+++ b/apps/dns-server/resources/sample-config.yaml
@@ -28,3 +28,7 @@ blocklist:
 cache:
   max_entries: 10000
   default_ttl_seconds: 300
+
+metrics:
+  endpoint: http://localhost:9090/api/v1/otlp/v1/metrics
+  interval_seconds: 30

--- a/apps/dns-server/src/config.rs
+++ b/apps/dns-server/src/config.rs
@@ -10,6 +10,7 @@ pub struct Configuration {
     pub upstream: UpstreamConfig,
     pub blocklist: BlocklistConfig,
     pub cache: CacheConfig,
+    pub metrics: MetricsConfig,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq, Deserialize)]
@@ -51,6 +52,12 @@ pub struct CacheConfig {
     pub default_ttl_seconds: u64,
 }
 
+#[derive(Clone, Debug, Eq, PartialEq, Deserialize)]
+pub struct MetricsConfig {
+    pub endpoint: String,
+    pub interval_seconds: u64,
+}
+
 #[cfg(test)]
 mod tests {
     use std::net::Ipv4Addr;
@@ -60,8 +67,8 @@ mod tests {
     use hickory_proto::xfer::Protocol;
 
     use crate::config::{
-        BlocklistConfig, CacheConfig, Configuration, ProtocolsConfig, ServerConfig, TlsConfig,
-        UpstreamConfig,
+        BlocklistConfig, CacheConfig, Configuration, MetricsConfig, ProtocolsConfig, ServerConfig,
+        TlsConfig, UpstreamConfig,
     };
 
     #[test]
@@ -101,6 +108,10 @@ mod tests {
             cache: CacheConfig {
                 max_entries: 10000,
                 default_ttl_seconds: 300,
+            },
+            metrics: MetricsConfig {
+                endpoint: "http://localhost:9090/api/v1/otlp/v1/metrics".to_string(),
+                interval_seconds: 30,
             },
         };
 

--- a/apps/dns-server/src/main.rs
+++ b/apps/dns-server/src/main.rs
@@ -37,11 +37,11 @@ async fn main() -> Result<()> {
     let exporter = MetricExporter::builder()
         .with_http()
         .with_http_client(Client::new())
-        .with_endpoint("http://localhost:9090/api/v1/otlp/v1/metrics")
+        .with_endpoint(config.metrics.endpoint.clone())
         .build()?;
 
     let reader = PeriodicReader::builder(exporter, runtime::Tokio)
-        .with_interval(Duration::from_secs(30))
+        .with_interval(Duration::from_secs(config.metrics.interval_seconds))
         .build();
     let provider = SdkMeterProvider::builder().with_reader(reader).build();
 


### PR DESCRIPTION
Currently the metrics endpoint is hardcoded, but it'll be different in production.

This change:
* Adds the ability to configure it
