### PR TITLE
feat: add DNS record for Grafana

### DIFF
--- a/infrastructure/terraform/aws.tf
+++ b/infrastructure/terraform/aws.tf
@@ -403,6 +403,7 @@ resource "aws_route53_record" "records" {
     "", // root record
     "certificates",
     "events",
+    "grafana",
     "lockers",
     "tags",
     "today",


### PR DESCRIPTION
Grafana is going to be deployed to the server alongside Prometheus, so we'll need a DNS record to acquire certificates for it.

This change:
* Adds the DNS record definition
