### PR TITLE
feat: allow routing to Prometheus

### DIFF
--- a/infrastructure/configuration/dns-server/config.yaml
+++ b/infrastructure/configuration/dns-server/config.yaml
@@ -30,5 +30,5 @@ cache:
   default_ttl_seconds: 300
 
 metrics:
-  endpoint: http://prometheus.mesh.internal:9090/api/v1/otlp/v1/metrics
+  endpoint: http://prometheus.mesh.internal/api/v1/otlp/v1/metrics
   interval_seconds: 30

--- a/infrastructure/configuration/f2/config.yaml
+++ b/infrastructure/configuration/f2/config.yaml
@@ -1,6 +1,7 @@
 alb:
   addr: 0.0.0.0
   ports:
+    http: 80
     https: 443
   reconciliation: /reconcile
   tls:

--- a/infrastructure/terraform/aws.tf
+++ b/infrastructure/terraform/aws.tf
@@ -327,7 +327,8 @@ module "secondary" {
     bucket = module.hackathon_bucket.name
   }
 
-  key_name = aws_key_pair.main.key_name
+  key_name               = aws_key_pair.main.key_name
+  inbound_http_subnet_id = aws_subnet.main.id
 }
 
 resource "aws_eip" "dns_server" {
@@ -479,4 +480,12 @@ resource "aws_route53_record" "rds_postgres" {
   type    = "CNAME"
   ttl     = 300
   records = [module.rds_postgres.address]
+}
+
+resource "aws_route53_record" "prometheus" {
+  zone_id = aws_route53_zone.internal.id
+  name    = "prometheus"
+  type    = "A"
+  ttl     = 300
+  records = [module.secondary.private_ip]
 }


### PR DESCRIPTION
`dns-server` needs to go to `f2`'s HTTP port instead of Prometheus directly, so let's open up the traffic and reconfigure it.

This change:
* Tells `f2` to run an HTTP port
* Allows traffic into `f2` on HTTP from the main subnet
* Adds a DNS record for Prometheus traffic
* Updates the configuration in `dns-server`
