### PR TITLE
refactor: separate metrics out

### DIFF
--- a/apps/dns-server/src/handler.rs
+++ b/apps/dns-server/src/handler.rs
@@ -4,10 +4,10 @@ use hickory_proto::op::{Message, MessageType, OpCode, ResponseCode};
 use hickory_server::authority::MessageResponseBuilder;
 use hickory_server::server::{Request, RequestHandler, ResponseHandler, ResponseInfo};
 use opentelemetry::KeyValue;
-use opentelemetry::metrics::{Counter, Histogram};
 
 use crate::blocklist::BlocklistManager;
 use crate::cache::ResponseCache;
+use crate::server::DnsServerMetrics;
 use crate::upstream::UpstreamResolver;
 
 #[derive(Clone)]
@@ -15,10 +15,7 @@ pub struct DnsRequestHandler {
     upstream: UpstreamResolver,
     blocklist: BlocklistManager,
     cache: ResponseCache,
-    requests: Counter<u64>,
-    responses: Counter<u64>,
-    request_duration: Histogram<f64>,
-    upstream_duration: Histogram<f64>,
+    metrics: DnsServerMetrics,
 }
 
 impl DnsRequestHandler {
@@ -26,19 +23,13 @@ impl DnsRequestHandler {
         upstream: UpstreamResolver,
         blocklist: BlocklistManager,
         cache: ResponseCache,
-        requests: Counter<u64>,
-        responses: Counter<u64>,
-        request_duration: Histogram<f64>,
-        upstream_duration: Histogram<f64>,
+        metrics: DnsServerMetrics,
     ) -> Self {
         Self {
             upstream,
             blocklist,
             cache,
-            requests,
-            responses,
-            request_duration,
-            upstream_duration,
+            metrics,
         }
     }
 }
@@ -50,7 +41,7 @@ impl RequestHandler for DnsRequestHandler {
         request: &Request,
         mut response_handle: R,
     ) -> ResponseInfo {
-        self.requests.add(1, &[]);
+        self.metrics.requests.add(1, &[]);
         let start = Instant::now();
 
         // Get request info to extract the query
@@ -69,7 +60,7 @@ impl RequestHandler for DnsRequestHandler {
                         ResponseInfo::from(*request.header())
                     }
                 };
-                self.request_duration.record(
+                self.metrics.request_duration.record(
                     start.elapsed().as_millis() as f64,
                     &[KeyValue::new("type", "parse-error")],
                 );
@@ -95,7 +86,7 @@ impl RequestHandler for DnsRequestHandler {
             );
 
             let attrs = [KeyValue::new("type", "explicit-block")];
-            self.responses.add(1, &attrs);
+            self.metrics.responses.add(1, &attrs);
 
             let response = MessageResponseBuilder::from_message_request(request)
                 .error_msg(&request.header().clone(), ResponseCode::Refused);
@@ -107,7 +98,8 @@ impl RequestHandler for DnsRequestHandler {
                     ResponseInfo::from(*request.header())
                 }
             };
-            self.request_duration
+            self.metrics
+                .request_duration
                 .record(start.elapsed().as_millis() as f64, &attrs);
             return result;
         }
@@ -124,7 +116,7 @@ impl RequestHandler for DnsRequestHandler {
             );
 
             let attrs = [KeyValue::new("type", "cache-hit")];
-            self.responses.add(1, &attrs);
+            self.metrics.responses.add(1, &attrs);
 
             // Build response from cached message with correct ID
             let mut header = *cached_response.header();
@@ -144,7 +136,8 @@ impl RequestHandler for DnsRequestHandler {
                     ResponseInfo::from(*request.header())
                 }
             };
-            self.request_duration
+            self.metrics
+                .request_duration
                 .record(start.elapsed().as_millis() as f64, &attrs);
             return result;
         }
@@ -187,10 +180,11 @@ impl RequestHandler for DnsRequestHandler {
                 (error_msg, "upstream-error")
             }
         };
-        self.upstream_duration
+        self.metrics
+            .upstream_duration
             .record(upstream_start.elapsed().as_millis() as f64, &[]);
         let attrs = [KeyValue::new("type", response_type)];
-        self.responses.add(1, &attrs);
+        self.metrics.responses.add(1, &attrs);
 
         let response = MessageResponseBuilder::from_message_request(request).build(
             *response_message.header(),
@@ -207,7 +201,8 @@ impl RequestHandler for DnsRequestHandler {
                 ResponseInfo::from(*request.header())
             }
         };
-        self.request_duration
+        self.metrics
+            .request_duration
             .record(start.elapsed().as_millis() as f64, &attrs);
         result
     }

--- a/apps/dns-server/src/main.rs
+++ b/apps/dns-server/src/main.rs
@@ -20,7 +20,7 @@ mod upstream;
 use crate::blocklist::BlocklistManager;
 use crate::cache::ResponseCache;
 use crate::config::Configuration;
-use crate::server::DnsServer;
+use crate::server::{DnsServer, DnsServerMetrics};
 use crate::tls::CertificateResolver;
 use crate::upstream::UpstreamResolver;
 
@@ -56,26 +56,7 @@ async fn main() -> Result<()> {
     let certificate_resolver = CertificateResolver::new(tls_config.clone()).await?;
 
     let meter = opentelemetry::global::meter("dns-server");
-
-    let requests = meter
-        .u64_counter("dns_requests_total")
-        .with_description("Total number of DNS requests received")
-        .build();
-
-    let responses = meter
-        .u64_counter("dns_responses_total")
-        .with_description("Total number of DNS responses sent")
-        .build();
-
-    let request_duration = meter
-        .f64_histogram("dns_request_duration_ms")
-        .with_description("End-to-end latency of DNS request handling in milliseconds")
-        .build();
-
-    let upstream_duration = meter
-        .f64_histogram("dns_upstream_duration_ms")
-        .with_description("Latency of upstream DNS resolution in milliseconds")
-        .build();
+    let metrics = DnsServerMetrics::new(&meter);
 
     let dns_server = DnsServer::new(
         upstream,
@@ -83,10 +64,7 @@ async fn main() -> Result<()> {
         cache,
         tls_config,
         certificate_resolver.clone(),
-        requests,
-        responses,
-        request_duration,
-        upstream_duration,
+        metrics,
     )
     .await?;
 

--- a/apps/dns-server/src/server.rs
+++ b/apps/dns-server/src/server.rs
@@ -5,7 +5,7 @@ use std::time::Duration;
 use color_eyre::eyre::Result;
 use foundation_shutdown::{CancellationToken, GracefulTask};
 use hickory_server::ServerFuture;
-use opentelemetry::metrics::{Counter, Histogram};
+use opentelemetry::metrics::{Counter, Histogram, Meter};
 use tokio::net::TcpListener;
 
 use crate::blocklist::BlocklistManager;
@@ -15,43 +15,52 @@ use crate::handler::DnsRequestHandler;
 use crate::tls::CertificateResolver;
 use crate::upstream::UpstreamResolver;
 
+#[derive(Clone)]
+pub struct DnsServerMetrics {
+    pub(crate) requests: Counter<u64>,
+    pub(crate) responses: Counter<u64>,
+    pub(crate) request_duration: Histogram<f64>,
+    pub(crate) upstream_duration: Histogram<f64>,
+}
+
+impl DnsServerMetrics {
+    pub fn new(meter: &Meter) -> Self {
+        Self {
+            requests: meter
+                .u64_counter("dns_requests_total")
+                .with_description("Total number of DNS requests received")
+                .build(),
+            responses: meter
+                .u64_counter("dns_responses_total")
+                .with_description("Total number of DNS responses sent")
+                .build(),
+            request_duration: meter
+                .f64_histogram("dns_request_duration_ms")
+                .with_description("End-to-end latency of DNS request handling in milliseconds")
+                .build(),
+            upstream_duration: meter
+                .f64_histogram("dns_upstream_duration_ms")
+                .with_description("Latency of upstream DNS resolution in milliseconds")
+                .build(),
+        }
+    }
+}
+
 pub struct DnsServer {
     server_future: ServerFuture<DnsRequestHandler>,
 }
 
 impl DnsServer {
-    #[tracing::instrument(skip(
-        upstream,
-        blocklist,
-        cache,
-        config,
-        certificate_resolver,
-        requests,
-        responses,
-        request_duration,
-        upstream_duration
-    ))]
-    #[allow(clippy::too_many_arguments)]
+    #[tracing::instrument(skip(upstream, blocklist, cache, config, certificate_resolver, metrics))]
     pub async fn new(
         upstream: UpstreamResolver,
         blocklist: BlocklistManager,
         cache: ResponseCache,
         config: &TlsConfig,
         certificate_resolver: CertificateResolver,
-        requests: Counter<u64>,
-        responses: Counter<u64>,
-        request_duration: Histogram<f64>,
-        upstream_duration: Histogram<f64>,
+        metrics: DnsServerMetrics,
     ) -> Result<Self> {
-        let handler = DnsRequestHandler::new(
-            upstream,
-            blocklist,
-            cache,
-            requests,
-            responses,
-            request_duration,
-            upstream_duration,
-        );
+        let handler = DnsRequestHandler::new(upstream, blocklist, cache, metrics);
         let mut server_future = ServerFuture::new(handler);
 
         register_tls_listener(&mut server_future, config, certificate_resolver).await?;


### PR DESCRIPTION
`clippy` is unhappy at the number of arguments, so let's split the metric counters and histograms out.

This change:
* Adds a `DnsServerMetrics` struct and begins using it
