### PR TITLE
feat: add volumes for observability

### DIFF
--- a/infrastructure/configuration/f2/config.yaml
+++ b/infrastructure/configuration/f2/config.yaml
@@ -277,6 +277,12 @@ services:
       GF_SECURITY_DISABLE_LOGIN_FORM: "true"
       GF_AUTH_ANONYMOUS_ENABLED: "true"
       GF_AUTH_ANONYMOUS_ORG_ROLE: Admin
+    volumes:
+      data:
+        source:
+          location: filesystem
+          path: /mnt/data/grafana
+        target: /var/lib/grafana
 
   prometheus:
     image: prom/prometheus
@@ -288,3 +294,9 @@ services:
     args:
       - --config.file=/etc/prometheus/prometheus.yml
       - --web.enable-otlp-receiver
+    volumes:
+      data:
+        source:
+          location: filesystem
+          path: /mnt/data/prometheus
+        target: /prometheus

--- a/infrastructure/terraform/aws.tf
+++ b/infrastructure/terraform/aws.tf
@@ -321,7 +321,7 @@ module "primary" {
   }
 
   extra_ebs_volume = {
-    size_gb     = 8
+    size_gb     = 2
     device_name = "/dev/sdf"
   }
 
@@ -356,7 +356,7 @@ module "secondary" {
   }
 
   extra_ebs_volume = {
-    size_gb     = 8
+    size_gb     = 2
     device_name = "/dev/sdf"
   }
 

--- a/infrastructure/terraform/aws.tf
+++ b/infrastructure/terraform/aws.tf
@@ -294,6 +294,41 @@ resource "aws_key_pair" "main" {
   public_key = file("./keys/id_rsa.pub")
 }
 
+module "primary" {
+  source = "./modules/f2-instance"
+  name   = "primary"
+
+  instance = {
+    type      = "t4g.micro"
+    ami       = "ami-0b583f82e876e016c"
+    vpc_id    = aws_vpc.main.id
+    subnet_id = aws_subnet.main.id
+  }
+
+  configuration = {
+    bucket    = module.config_bucket.name
+    key       = "f2/config.yaml"
+    image_tag = "20260530-1116"
+  }
+
+  logging = {
+    bucket     = module.logging_bucket.name
+    vector_tag = "0.55.0-alpine"
+  }
+
+  hackathon = {
+    bucket = module.hackathon_bucket.name
+  }
+
+  extra_ebs_volume = {
+    size_gb     = 8
+    device_name = "/dev/sdf"
+  }
+
+  key_name               = aws_key_pair.main.key_name
+  inbound_http_subnet_id = aws_subnet.main.id
+}
+
 module "secondary" {
   source = "./modules/f2-instance"
   name   = "primsecondary"
@@ -318,6 +353,11 @@ module "secondary" {
 
   hackathon = {
     bucket = module.hackathon_bucket.name
+  }
+
+  extra_ebs_volume = {
+    size_gb     = 8
+    device_name = "/dev/sdf"
   }
 
   key_name               = aws_key_pair.main.key_name
@@ -450,6 +490,16 @@ module "rds_postgres" {
 
   allow_major_version_upgrade = true
   apply_immediately           = true
+}
+
+resource "aws_security_group_rule" "primary_to_postgres" {
+  description              = "Allow inbound PostgreSQL from primary"
+  type                     = "ingress"
+  from_port                = 5432
+  to_port                  = 5432
+  protocol                 = "tcp"
+  source_security_group_id = module.primary.security_group_id
+  security_group_id        = module.rds_postgres.security_group_id
 }
 
 resource "aws_security_group_rule" "secondary_to_postgres" {


### PR DESCRIPTION
Every time `f2` needs a restart, we have to kill Grafana and Prometheus which means all the data and configuration goes.

This change:
* Adds an EBS volume and mounts paths into the containers
