### PR TITLE
feat: produce HTTP metrics

### DIFF
--- a/apps/Cargo.lock
+++ b/apps/Cargo.lock
@@ -1454,9 +1454,6 @@ dependencies = [
  "hickory-server 0.26.1",
  "moka",
  "opentelemetry",
- "opentelemetry-otlp",
- "opentelemetry_sdk",
- "reqwest",
  "rustls 0.23.40",
  "rustls-pemfile",
  "serde",
@@ -1762,6 +1759,7 @@ version = "0.1.0"
 dependencies = [
  "axum",
  "color-eyre",
+ "foundation-metrics",
  "foundation-shutdown",
  "reqwest",
  "tokio",
@@ -1780,6 +1778,7 @@ dependencies = [
  "foundation-configuration",
  "foundation-database-bootstrap",
  "foundation-logging",
+ "foundation-metrics",
  "foundation-telemetry",
  "serde",
  "tracing",
@@ -1793,6 +1792,22 @@ dependencies = [
  "tracing",
  "tracing-error",
  "tracing-subscriber",
+]
+
+[[package]]
+name = "foundation-metrics"
+version = "0.1.0"
+dependencies = [
+ "axum",
+ "color-eyre",
+ "opentelemetry",
+ "opentelemetry-otlp",
+ "opentelemetry_sdk",
+ "pin-project-lite",
+ "reqwest",
+ "serde",
+ "tower-layer",
+ "tower-service",
 ]
 
 [[package]]

--- a/apps/Cargo.toml
+++ b/apps/Cargo.toml
@@ -11,6 +11,7 @@ members = [
 	"foundation/http-server",
 	"foundation/init",
 	"foundation/logging",
+	"foundation/metrics",
 	"foundation/recurring-job",
 	"foundation/shutdown",
 	"foundation/telemetry",
@@ -27,6 +28,9 @@ members = [
 
 [workspace.dependencies]
 axum = "0.8.9"
+opentelemetry = "0.32.0"
+opentelemetry-otlp = "0.32.0"
+opentelemetry_sdk = "0.32.0"
 reqwest = { version = "0.13.4", default-features = false, features = ["rustls"] }
 serde = "1.0.219"
 tracing = "0.1.41"

--- a/apps/certmanager/Cargo.toml
+++ b/apps/certmanager/Cargo.toml
@@ -10,8 +10,8 @@ axum.workspace = true
 color-eyre = "0.6.3"
 foundation-configuration = { version = "0.1.0", path = "../foundation/configuration" }
 foundation-credentials = { version = "0.1.0", path = "../foundation/credentials" }
-foundation-http-server = { version = "0.1.0", path = "../foundation/http-server" }
-foundation-init = { version = "0.1.0", path = "../foundation/init", features = ["database"] }
+foundation-http-server = { version = "0.1.0", path = "../foundation/http-server", features = ["metrics"] }
+foundation-init = { version = "0.1.0", path = "../foundation/init", features = ["database", "metrics"] }
 foundation-recurring-job = { version = "0.1.0", path = "../foundation/recurring-job" }
 foundation-shutdown = { version = "0.1.0", path = "../foundation/shutdown" }
 foundation-templating = { version = "0.1.0", path = "../foundation/templating" }

--- a/apps/certmanager/local-config.yaml
+++ b/apps/certmanager/local-config.yaml
@@ -23,3 +23,7 @@ storage:
 acme:
   environment: staging
   contact: alexanderjackson@protonmail.com
+
+metrics:
+  endpoint: "http://localhost:9090/api/v1/otlp/v1/metrics"
+  interval_seconds: 15

--- a/apps/dns-server/Cargo.toml
+++ b/apps/dns-server/Cargo.toml
@@ -8,7 +8,7 @@ async-trait = "0.1.89"
 bytes = "1.11.0"
 color-eyre = "0.6.5"
 foundation-configuration = { version = "0.1.0", path = "../foundation/configuration", features = ["external-bytes"] }
-foundation-init = { version = "0.1.0", path = "../foundation/init" }
+foundation-init = { version = "0.1.0", path = "../foundation/init", features = ["metrics"] }
 foundation-recurring-job = { version = "0.1.0", path = "../foundation/recurring-job" }
 foundation-shutdown = { version = "0.1.0", path = "../foundation/shutdown" }
 hickory-dns = { version = "0.26.1", default-features = false, features = ["resolver"] }
@@ -22,10 +22,7 @@ tokio = { version = "1.48.0", features = ["macros", "rt-multi-thread", "net", "t
 tracing.workspace = true
 rustls-pemfile = "2.0"
 rustls = { version = "0.23", features = ["ring"] }
-opentelemetry_sdk = { version = "0.32.0", features = ["metrics", "rt-tokio", "experimental_metrics_periodicreader_with_async_runtime"] }
-opentelemetry-otlp = { version = "0.32.0", features = ["metrics", "http-proto", "reqwest-client"] }
-opentelemetry = "0.32.0"
-reqwest.workspace = true
+opentelemetry = { workspace = true }
 
 [dev-dependencies]
 dns-mock-server = "0.1.6"

--- a/apps/dns-server/local-config.yaml
+++ b/apps/dns-server/local-config.yaml
@@ -26,3 +26,7 @@ blocklist:
 cache:
   max_entries: 10000
   default_ttl_seconds: 300
+
+metrics:
+  endpoint: http://localhost:9090/api/v1/otlp/v1/metrics
+  interval_seconds: 15

--- a/apps/dns-server/resources/sample-config.yaml
+++ b/apps/dns-server/resources/sample-config.yaml
@@ -28,7 +28,3 @@ blocklist:
 cache:
   max_entries: 10000
   default_ttl_seconds: 300
-
-metrics:
-  endpoint: http://localhost:9090/api/v1/otlp/v1/metrics
-  interval_seconds: 30

--- a/apps/dns-server/src/config.rs
+++ b/apps/dns-server/src/config.rs
@@ -10,7 +10,6 @@ pub struct Configuration {
     pub upstream: UpstreamConfig,
     pub blocklist: BlocklistConfig,
     pub cache: CacheConfig,
-    pub metrics: MetricsConfig,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq, Deserialize)]
@@ -52,12 +51,6 @@ pub struct CacheConfig {
     pub default_ttl_seconds: u64,
 }
 
-#[derive(Clone, Debug, Eq, PartialEq, Deserialize)]
-pub struct MetricsConfig {
-    pub endpoint: String,
-    pub interval_seconds: u64,
-}
-
 #[cfg(test)]
 mod tests {
     use std::net::Ipv4Addr;
@@ -67,8 +60,8 @@ mod tests {
     use hickory_net::xfer::Protocol;
 
     use crate::config::{
-        BlocklistConfig, CacheConfig, Configuration, MetricsConfig, ProtocolsConfig, ServerConfig,
-        TlsConfig, UpstreamConfig,
+        BlocklistConfig, CacheConfig, Configuration, ProtocolsConfig, ServerConfig, TlsConfig,
+        UpstreamConfig,
     };
 
     #[test]
@@ -108,10 +101,6 @@ mod tests {
             cache: CacheConfig {
                 max_entries: 10000,
                 default_ttl_seconds: 300,
-            },
-            metrics: MetricsConfig {
-                endpoint: "http://localhost:9090/api/v1/otlp/v1/metrics".to_string(),
-                interval_seconds: 30,
             },
         };
 

--- a/apps/dns-server/src/main.rs
+++ b/apps/dns-server/src/main.rs
@@ -1,13 +1,6 @@
-use std::time::Duration;
-
 use color_eyre::eyre::Result;
 use foundation_recurring_job::RecurringJob;
 use foundation_shutdown::ShutdownCoordinator;
-use opentelemetry_otlp::{MetricExporter, WithExportConfig, WithHttpConfig};
-use opentelemetry_sdk::metrics::SdkMeterProvider;
-use opentelemetry_sdk::metrics::periodic_reader_with_async_runtime::PeriodicReader;
-use opentelemetry_sdk::runtime;
-use reqwest::Client;
 
 mod blocklist;
 mod cache;
@@ -33,19 +26,6 @@ async fn main() -> Result<()> {
         upstream = %config.upstream.resolver,
         "dns server initialized"
     );
-
-    let exporter = MetricExporter::builder()
-        .with_http()
-        .with_http_client(Client::new())
-        .with_endpoint(config.metrics.endpoint.clone())
-        .build()?;
-
-    let reader = PeriodicReader::builder(exporter, runtime::Tokio)
-        .with_interval(Duration::from_secs(config.metrics.interval_seconds))
-        .build();
-    let provider = SdkMeterProvider::builder().with_reader(reader).build();
-
-    opentelemetry::global::set_meter_provider(provider);
 
     let blocklist = BlocklistManager::new(config.blocklist.clone()).await?;
     let upstream = UpstreamResolver::new(&config.upstream).await?;

--- a/apps/events/.env
+++ b/apps/events/.env
@@ -1,1 +1,1 @@
-DATABASE_URL=postgres://localhost/events
+DATABASE_URL=postgres://postgres:test@localhost/events

--- a/apps/events/Cargo.toml
+++ b/apps/events/Cargo.toml
@@ -12,8 +12,8 @@ axum.workspace = true
 chrono = { version = "0.4.45", default-features = false, features = ["now", "serde"] }
 chrono-tz = { version = "0.10.4", features = ["serde"] }
 color-eyre = "0.6.3"
-foundation-http-server = { version = "0.1.0", path = "../foundation/http-server" }
-foundation-init = { version = "0.1.0", path = "../foundation/init", features = ["database"] }
+foundation-http-server = { version = "0.1.0", path = "../foundation/http-server", features = ["metrics"] }
+foundation-init = { version = "0.1.0", path = "../foundation/init", features = ["database", "metrics"] }
 foundation-shutdown = { version = "0.1.0", path = "../foundation/shutdown" }
 foundation-templating = { version = "0.1.0", path = "../foundation/templating" }
 itertools = "0.14.0"

--- a/apps/events/local-config.yaml
+++ b/apps/events/local-config.yaml
@@ -10,6 +10,10 @@ telemetry:
   enabled: false
   endpoint: "http://localhost:4318/v1/traces"
 
+metrics:
+  endpoint: "http://localhost:9090/api/v1/otlp/v1/metrics"
+  interval_seconds: 15
+
 database:
   host: localhost
   port: 5432

--- a/apps/foundation/http-server/Cargo.toml
+++ b/apps/foundation/http-server/Cargo.toml
@@ -3,9 +3,13 @@ name = "foundation-http-server"
 version = "0.1.0"
 edition = "2024"
 
+[features]
+metrics = ["dep:foundation-metrics"]
+
 [dependencies]
 axum = "0.8.9"
 color-eyre = "0.6.5"
+foundation-metrics = { version = "0.1.0", path = "../metrics", optional = true }
 foundation-shutdown = { version = "0.1.0", path = "../shutdown" }
 tokio = { version = "1.47.1", default-features = false, features = ["net"] }
 tower-http = { version = "0.6.8", features = ["trace"] }

--- a/apps/foundation/http-server/src/lib.rs
+++ b/apps/foundation/http-server/src/lib.rs
@@ -77,12 +77,17 @@ impl GracefulTask for Server {
             shutdown.cancelled().await;
         };
 
+        let router = self.router;
+
+        #[cfg(feature = "metrics")]
+        let router = router.route_layer(foundation_metrics::http_layer());
+
         let trace_layer = TraceLayer::new_for_http()
             .make_span_with(SpanCreator)
             .on_request(RequestTracingFilter::default())
             .on_response(ResponseTracingFilter::default());
 
-        let router = self.router.layer(trace_layer);
+        let router = router.layer(trace_layer);
 
         let addr = self.listener.local_addr()?;
         tracing::info!(%addr, "listening for incoming requests");

--- a/apps/foundation/init/Cargo.toml
+++ b/apps/foundation/init/Cargo.toml
@@ -8,6 +8,7 @@ color-eyre = "0.6.5"
 foundation-args = { version = "0.1.0", path = "../args" }
 foundation-configuration = { version = "0.1.0", path = "../configuration" }
 foundation-database-bootstrap = { version = "0.1.0", path = "../database-bootstrap", optional = true }
+foundation-metrics = { version = "0.1.0", path = "../metrics", optional = true }
 foundation-logging = { version = "0.1.0", path = "../logging" }
 foundation-telemetry = { version = "0.1.0", path = "../telemetry" }
 serde = { workspace = true, features = ["derive"] }
@@ -16,3 +17,4 @@ tracing-subscriber = "0.3.23"
 
 [features]
 database = ["dep:foundation-database-bootstrap"]
+metrics = ["dep:foundation-metrics"]

--- a/apps/foundation/init/src/lib.rs
+++ b/apps/foundation/init/src/lib.rs
@@ -17,6 +17,8 @@ pub struct Configuration<T> {
     #[cfg(feature = "database")]
     pub database: DatabaseConfiguration,
     pub telemetry: Option<TelemetryConfig>,
+    #[cfg(feature = "metrics")]
+    pub metrics: Option<foundation_metrics::MetricsConfig>,
 }
 
 impl<T> Deref for Configuration<T> {
@@ -54,6 +56,11 @@ where
             foundation_telemetry::get_trace_layer(application_name.clone(), &telemetry.endpoint)?;
 
         telemetry_reload_handle.reload(Some(layer))?;
+    }
+
+    #[cfg(feature = "metrics")]
+    if let Some(metrics) = &config.metrics {
+        foundation_metrics::init(&application_name, metrics)?;
     }
 
     tracing::info!(name = %application_name, "initialised application");

--- a/apps/foundation/metrics/Cargo.toml
+++ b/apps/foundation/metrics/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "foundation-metrics"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]
+axum = { workspace = true }
+color-eyre = "0.6.3"
+opentelemetry = { workspace = true }
+opentelemetry-otlp = { workspace = true, features = ["metrics", "http-proto", "reqwest-client"] }
+opentelemetry_sdk = { workspace = true, features = ["metrics", "rt-tokio", "experimental_metrics_periodicreader_with_async_runtime"] }
+pin-project-lite = "0.2"
+reqwest = { workspace = true }
+serde = { workspace = true, features = ["derive"] }
+tower-layer = "0.3.3"
+tower-service = "0.3.3"

--- a/apps/foundation/metrics/src/lib.rs
+++ b/apps/foundation/metrics/src/lib.rs
@@ -1,0 +1,152 @@
+use std::future::Future;
+use std::pin::Pin;
+use std::task::{Context, Poll};
+use std::time::Duration;
+
+use axum::extract::MatchedPath;
+use axum::http::{Request, Response};
+use opentelemetry::KeyValue;
+use opentelemetry::metrics::Counter;
+use opentelemetry_otlp::{MetricExporter, WithExportConfig, WithHttpConfig};
+use opentelemetry_sdk::Resource;
+use opentelemetry_sdk::metrics::SdkMeterProvider;
+use opentelemetry_sdk::metrics::periodic_reader_with_async_runtime::PeriodicReader;
+use opentelemetry_sdk::runtime;
+use pin_project_lite::pin_project;
+use reqwest::Client;
+use serde::Deserialize;
+use tower_layer::Layer;
+use tower_service::Service;
+
+#[derive(Clone, Debug, Deserialize)]
+pub struct MetricsConfig {
+    pub endpoint: String,
+    pub interval_seconds: u64,
+}
+
+pub fn init(service_name: &str, config: &MetricsConfig) -> color_eyre::eyre::Result<()> {
+    let exporter = MetricExporter::builder()
+        .with_http()
+        .with_http_client(Client::new())
+        .with_endpoint(config.endpoint.clone())
+        .build()?;
+
+    let reader = PeriodicReader::builder(exporter, runtime::Tokio)
+        .with_interval(Duration::from_secs(config.interval_seconds))
+        .build();
+
+    let resource = Resource::builder()
+        .with_service_name(service_name.to_owned())
+        .build();
+
+    let provider = SdkMeterProvider::builder()
+        .with_resource(resource)
+        .with_reader(reader)
+        .build();
+
+    opentelemetry::global::set_meter_provider(provider);
+
+    Ok(())
+}
+
+pub fn http_layer() -> HttpMetricsLayer {
+    HttpMetricsLayer::new()
+}
+
+#[derive(Clone)]
+pub struct HttpMetricsLayer {
+    counter: Counter<u64>,
+}
+
+impl HttpMetricsLayer {
+    fn new() -> Self {
+        let meter = opentelemetry::global::meter("http");
+        let counter = meter
+            .u64_counter("http_requests_total")
+            .with_description("Total HTTP responses by path and status code")
+            .build();
+        Self { counter }
+    }
+}
+
+impl<S> Layer<S> for HttpMetricsLayer {
+    type Service = HttpMetrics<S>;
+
+    fn layer(&self, service: S) -> Self::Service {
+        HttpMetrics {
+            counter: self.counter.clone(),
+            service,
+        }
+    }
+}
+
+#[derive(Clone)]
+pub struct HttpMetrics<S> {
+    counter: Counter<u64>,
+    service: S,
+}
+
+impl<S, ReqBody, ResBody> Service<Request<ReqBody>> for HttpMetrics<S>
+where
+    S: Service<Request<ReqBody>, Response = Response<ResBody>>,
+{
+    type Response = Response<ResBody>;
+    type Error = S::Error;
+    type Future = HttpMetricsFuture<S::Future>;
+
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        self.service.poll_ready(cx)
+    }
+
+    fn call(&mut self, request: Request<ReqBody>) -> Self::Future {
+        let path = request
+            .extensions()
+            .get::<MatchedPath>()
+            .map(|p| p.as_str().to_string())
+            .unwrap_or_else(|| request.uri().path().to_string());
+
+        let future = self.service.call(request);
+
+        HttpMetricsFuture {
+            inner: future,
+            counter: self.counter.clone(),
+            path,
+        }
+    }
+}
+
+pin_project! {
+    pub struct HttpMetricsFuture<F> {
+        #[pin]
+        inner: F,
+        counter: Counter<u64>,
+        path: String,
+    }
+}
+
+impl<F, B, E> Future for HttpMetricsFuture<F>
+where
+    F: Future<Output = Result<Response<B>, E>>,
+{
+    type Output = F::Output;
+
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        let this = self.project();
+
+        match this.inner.poll(cx) {
+            Poll::Ready(Ok(response)) => {
+                let status = response.status().as_u16().to_string();
+                this.counter.add(
+                    1,
+                    &[
+                        KeyValue::new("path", this.path.clone()),
+                        KeyValue::new("status_code", status),
+                    ],
+                );
+                Poll::Ready(Ok(response))
+            }
+            Poll::Ready(Err(e)) => Poll::Ready(Err(e)),
+            Poll::Pending => Poll::Pending,
+        }
+    }
+}

--- a/apps/foundation/metrics/src/lib.rs
+++ b/apps/foundation/metrics/src/lib.rs
@@ -62,7 +62,7 @@ impl HttpMetricsLayer {
     fn new() -> Self {
         let meter = opentelemetry::global::meter("http");
         let counter = meter
-            .u64_counter("http_requests_total")
+            .u64_counter("http_responses_total")
             .with_description("Total HTTP responses by path and status code")
             .build();
         Self { counter }

--- a/apps/foundation/telemetry/Cargo.toml
+++ b/apps/foundation/telemetry/Cargo.toml
@@ -5,9 +5,9 @@ edition = "2024"
 
 [dependencies]
 color-eyre = { version = "0.6.5", default-features = false }
-opentelemetry = "0.32.0"
-opentelemetry-otlp = "0.32.0"
-opentelemetry_sdk = "0.32.0"
+opentelemetry = { workspace = true }
+opentelemetry-otlp = { workspace = true }
+opentelemetry_sdk = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 tracing-core = "0.1.34"
 tracing-opentelemetry = "0.33.0"

--- a/apps/lockers/.env
+++ b/apps/lockers/.env
@@ -1,1 +1,1 @@
-DATABASE_URL=postgresql://alex@localhost/lockers
+DATABASE_URL=postgresql://postgres:test@localhost/lockers

--- a/apps/lockers/Cargo.toml
+++ b/apps/lockers/Cargo.toml
@@ -11,8 +11,8 @@ path = "src/main.rs"
 axum.workspace = true
 chrono = { version = "0.4.45", default-features = false, features = ["now", "serde"] }
 color-eyre = "0.6.3"
-foundation-http-server = { version = "0.1.0", path = "../foundation/http-server" }
-foundation-init = { version = "0.1.0", path = "../foundation/init", features = ["database"] }
+foundation-http-server = { version = "0.1.0", path = "../foundation/http-server", features = ["metrics"] }
+foundation-init = { version = "0.1.0", path = "../foundation/init", features = ["database", "metrics"] }
 foundation-shutdown = { version = "0.1.0", path = "../foundation/shutdown" }
 foundation-uid = { version = "0.1.0", path = "../foundation/uid" }
 serde = { workspace = true, features = ["derive"] }

--- a/apps/lockers/local-config.yaml
+++ b/apps/lockers/local-config.yaml
@@ -6,6 +6,10 @@ telemetry:
   enabled: false
   endpoint: "http://localhost:4318/v1/traces"
 
+metrics:
+  endpoint: "http://localhost:9090/api/v1/otlp/v1/metrics"
+  interval_seconds: 15
+
 database:
   host: localhost
   port: 5432

--- a/apps/tag-updater/Cargo.toml
+++ b/apps/tag-updater/Cargo.toml
@@ -10,8 +10,8 @@ axum.workspace = true
 axum-extra = { version = "0.12.6", features = ["typed-header"] }
 color-eyre = { version = "0.6.5", default-features = false }
 foundation-configuration = { path = "../foundation/configuration", features = ["external-bytes"] }
-foundation-http-server = { version = "0.1.0", path = "../foundation/http-server" }
-foundation-init = { version = "0.1.0", path = "../foundation/init" }
+foundation-http-server = { version = "0.1.0", path = "../foundation/http-server", features = ["metrics"] }
+foundation-init = { version = "0.1.0", path = "../foundation/init", features = ["metrics"] }
 foundation-shutdown = { version = "0.1.0", path = "../foundation/shutdown" }
 foundation-telemetry = { version = "0.1.0", path = "../foundation/telemetry" }
 git2 = { version = "0.21.0", default-features = false, features = ["ssh"] }

--- a/apps/today/.env
+++ b/apps/today/.env
@@ -1,2 +1,2 @@
-DATABASE_URL=postgresql://localhost:5432/today
+DATABASE_URL=postgresql://postgres:test@localhost:5432/today
 RUST_LOG=info

--- a/apps/today/Cargo.toml
+++ b/apps/today/Cargo.toml
@@ -8,8 +8,8 @@ axum.workspace = true
 chrono = { version = "0.4.45", default-features = false, features = ["now"] }
 color-eyre = "0.6.3"
 dotenvy = "0.15.7"
-foundation-http-server = { version = "0.1.0", path = "../foundation/http-server" }
-foundation-init = { version = "0.1.0", path = "../foundation/init", features = ["database"] }
+foundation-http-server = { version = "0.1.0", path = "../foundation/http-server", features = ["metrics"] }
+foundation-init = { version = "0.1.0", path = "../foundation/init", features = ["database", "metrics"] }
 foundation-shutdown = { version = "0.1.0", path = "../foundation/shutdown" }
 foundation-uid = { version = "0.1.0", path = "../foundation/uid" }
 moka = { version = "0.12.15", features = ["future"] }

--- a/apps/today/local-config.yaml
+++ b/apps/today/local-config.yaml
@@ -6,13 +6,17 @@ telemetry:
   enabled: false
   endpoint: "http://localhost:4318/v1/traces"
 
+metrics:
+  endpoint: "http://localhost:9090/api/v1/otlp/v1/metrics"
+  interval_seconds: 15
+
 database:
   host: localhost
   port: 5432
 
   root:
-    username: alex
-    password: ""
+    username: postgres
+    password: test
     database: postgres
 
   application:

--- a/apps/uptime/.env
+++ b/apps/uptime/.env
@@ -12,5 +12,5 @@ APP_DATABASE=uptime
 DATABASE_HOST=localhost
 DATABASE_PORT=5432
 
-DATABASE_URL=postgresql://localhost:5432/uptime
+DATABASE_URL=postgresql://postgres:test@localhost:5432/uptime
 RUST_LOG=info

--- a/apps/uptime/Cargo.toml
+++ b/apps/uptime/Cargo.toml
@@ -9,8 +9,8 @@ axum.workspace = true
 chrono = { version = "0.4.45", features = ["serde"] }
 color-eyre = "0.6.3"
 dotenvy = "0.15.7"
-foundation-http-server = { version = "0.1.0", path = "../foundation/http-server" }
-foundation-init = { version = "0.1.0", path = "../foundation/init", features = ["database"] }
+foundation-http-server = { version = "0.1.0", path = "../foundation/http-server", features = ["metrics"] }
+foundation-init = { version = "0.1.0", path = "../foundation/init", features = ["database", "metrics"] }
 foundation-recurring-job = { version = "0.1.0", path = "../foundation/recurring-job" }
 foundation-shutdown = { version = "0.1.0", path = "../foundation/shutdown" }
 humantime = "2.1.0"

--- a/apps/uptime/local-config.yaml
+++ b/apps/uptime/local-config.yaml
@@ -17,3 +17,7 @@ database:
 
 routing:
   sns_topic: ""
+
+metrics:
+  endpoint: "http://localhost:9090/api/v1/otlp/v1/metrics"
+  interval_seconds: 15

--- a/infrastructure/configuration/certmanager/config.yaml
+++ b/infrastructure/configuration/certmanager/config.yaml
@@ -27,3 +27,7 @@ acme:
 notify:
   url: https://certificates.opentracker.app
   path: /certificates
+
+metrics:
+  endpoint: http://prometheus.mesh.internal/api/v1/otlp/v1/metrics
+  interval_seconds: 30

--- a/infrastructure/configuration/events/config.yaml
+++ b/infrastructure/configuration/events/config.yaml
@@ -19,3 +19,7 @@ database:
     username: eventsblue
     password: {{ Xo1Tyv2L+SJ9kF5sR/JGMa/HeO7XHPP7i2l9ugkGnTdQ5M8M2K6Vs8nx7Fwr89AFrbm+ECv3uBBw68xF/keLkHgdpdAHbKxlyFrbj1WDPSgdKTys5pWsyoi7gYYfFXI7Vdtrx4owEtoTR1ZGWBeL7Zvz560nExD6H1/dTbRv6yI2koLzX/M1GctxPyiVFYAZc2BERvWOmaQG4TGRcLWwW/BKvzD0VEFP47mS+VdmdQ8vYu7MisJBuybaqDjsu7/HEbqPKN1rgvvtuhkFo2cM18812xWey1V4BrlGMJrw9QJ/HrwVRELOXIjHkRZC98RgcFuJtvvJFvU1ccM4PcWeBA== }}
     database: events
+
+metrics:
+  endpoint: http://prometheus.mesh.internal/api/v1/otlp/v1/metrics
+  interval_seconds: 30

--- a/infrastructure/configuration/lockers/config.yaml
+++ b/infrastructure/configuration/lockers/config.yaml
@@ -15,3 +15,7 @@ database:
     username: lockersblue
     password: {{ p14wo3EmXg7PHh2rXCX2OrXaJ9uwtNuzS7yRqxPSDeQbxCKEIRI2pqjCZL7m2IFbr7lpFWiAYEqLdD53E2Eo2RKOLWdaHsvPV3hvuhMrFOx1U1dtpBhhcYQSyhrvZmMgcalcBArnavDo8kFuuDTZvigRcves7jM62vgzsZXg1AO97oDwscQ2pIOBdn/2z7gLxeMhmLnu/tmGQ4ORfkb9nIEasgJHVhAMmjql3YlhqxUR0Tg6aimyLEw2f1cxQIiQXZinE2cgEDvmNQZxwPKpMbtSn4uZDkkLtW0IMoPBHj7kSqjLN6mXvUOtmHbodaQBJUOva7RT6BFLIYdgncAK6Q== }}
     database: lockers
+
+metrics:
+  endpoint: http://prometheus.mesh.internal/api/v1/otlp/v1/metrics
+  interval_seconds: 30

--- a/infrastructure/configuration/tag-updater/config.yaml
+++ b/infrastructure/configuration/tag-updater/config.yaml
@@ -11,3 +11,7 @@ private_key:
   location: s3
   bucket: configuration-68f6c7
   key: tag-updater/id_rsa
+
+metrics:
+  endpoint: http://prometheus.mesh.internal/api/v1/otlp/v1/metrics
+  interval_seconds: 30

--- a/infrastructure/configuration/today/config.yaml
+++ b/infrastructure/configuration/today/config.yaml
@@ -15,3 +15,7 @@ database:
     username: "todayblue"
     password: {{ fFalHq733TmgACKeryFW2TzppYtn7H5FDquPx4Z7Dh76Mgq5Zz4DS+iOmSzWIhC4RDC8+U7b2NKUGnWzEAEM3ltF1v5I029Wlv6nOHo5pGHWEPseaPmvrk3mfupyK+FDsDnVyXJ35QNBvJEgEIJHAzNd79hGTcdHU5WlXsIrIP9FPH4dw72ATAkdaNP1zgKriUx5luYYONlM+H81zmWCt1XX9gRG3Y8eSMwAgIZQcfFvvGZ4+CNJJfQRrPMX1mQfGTjtSQ10p9YqdEuNrJvxxsoMXgrsxJRE5Qr8sc+QYBn1f5CKFXw23QoupBFUR6Dggoi+Z1xUoVOE2Ly8zI1kRQ== }}
     database: "today"
+
+metrics:
+  endpoint: http://prometheus.mesh.internal/api/v1/otlp/v1/metrics
+  interval_seconds: 30

--- a/infrastructure/configuration/uptime/config.yaml
+++ b/infrastructure/configuration/uptime/config.yaml
@@ -17,3 +17,7 @@ database:
 
 routing:
   sns_topic: arn:aws:sns:eu-west-1:558855412466:outages
+
+metrics:
+  endpoint: http://prometheus.mesh.internal/api/v1/otlp/v1/metrics
+  interval_seconds: 30

--- a/infrastructure/generate-certificates.sh
+++ b/infrastructure/generate-certificates.sh
@@ -17,7 +17,7 @@ function generate_client_cert() {
 	# Generate a key, CSR and certificate for the client
 	openssl genrsa -out "$client_name.key" 2048 2>/dev/null
 	openssl req -new -key "$client_name.key" -subj "/C=GB/ST=England/L=London/O=client/CN=$common_name" -addext "subjectAltName = DNS:localhost" -out "$client_name.csr" 2>/dev/null
-	openssl x509 -req -in "$client_name.csr" -CA ca.crt -CAkey ca.key -CAcreateserial -extfile <(printf "subjectAltName=DNS:localhost") -days 365 -out "$client_name.crt" 2>/dev/null
+	openssl x509 -req -in "$client_name.csr" -CA ca.crt -CAkey ca.key -CAcreateserial -extfile <(printf "subjectAltName=DNS:localhost") -days 1825 -out "$client_name.crt" 2>/dev/null
 
 	# Generate a PEM file for `curl` and a `p12` for browser usage
 	cat "$client_name.crt" "$client_name.key" > "$client_name.pem"
@@ -39,13 +39,13 @@ function generate_from_scratch() {
 	# Generate a key for the CA as well as a self-signed certificate
 	echo "Generating root CA..."
 	openssl genrsa -out ca.key 2048 2>/dev/null
-	openssl req -new -x509 -key ca.key -out ca.crt -subj "/C=GB/ST=England/L=London/O=root/CN=localhost" 2>/dev/null
+	openssl req -new -x509 -key ca.key -out ca.crt -subj "/C=GB/ST=England/L=London/O=root/CN=localhost" -days 1825 2>/dev/null
 
 	# Generate a key, CSR and certificate for the server
 	echo "Generating server certificate..."
 	openssl genrsa -out localhost.key 2048 2>/dev/null
 	openssl req -new -key localhost.key -subj "/C=GB/ST=England/L=London/O=server/CN=localhost" -addext "subjectAltName = DNS:localhost" -out localhost.csr 2>/dev/null
-	openssl x509 -req -in localhost.csr -CA ca.crt -CAkey ca.key -CAcreateserial -extfile <(printf "subjectAltName=DNS:localhost") -out localhost.crt 2>/dev/null
+	openssl x509 -req -in localhost.csr -CA ca.crt -CAkey ca.key -CAcreateserial -extfile <(printf "subjectAltName=DNS:localhost") -days 1825 -out localhost.crt 2>/dev/null
 
 	# Concatenate the certificates for the server to use
 	cat localhost.crt ca.crt > localhost.bundle.crt
@@ -117,20 +117,16 @@ function package_mobile() {
 	openssl x509 -outform der -in ca.crt -out dist/clients/mobile/android/ca.der 2>/dev/null
 
 	echo "Creating PKCS12 bundle with full certificate chain..."
-	# Create a full chain PEM (client cert + CA cert)
-	cat mobile.crt ca.crt > mobile.chain.pem
-	cat mobile.chain.pem mobile.key > mobile.full.pem
 
-	# Create PKCS12 with the full chain (with password for Android compatibility)
-	# Using AES-256-CBC and SHA256 for Android compatibility
-	/usr/bin/openssl pkcs12 -export \
+	# Use homebrew OpenSSL 3 — LibreSSL (/usr/bin/openssl) defaults the PBKDF2 PRF to
+	# hmacWithSHA1 even with AES-256-CBC, which Android 14+ rejects. OpenSSL 3 defaults
+	# to hmacWithSHA256, producing a PKCS12 Android accepts.
+	/opt/homebrew/bin/openssl pkcs12 -export \
 		-in mobile.crt \
 		-inkey mobile.key \
 		-certfile ca.crt \
 		-out dist/clients/mobile/android/mobile-with-ca.p12 \
 		-name "Pixel 6" \
-		-keypbe AES-256-CBC \
-		-certpbe AES-256-CBC \
 		-macalg sha256 \
 		-passout pass:password
 
@@ -168,7 +164,7 @@ function package_mobile() {
 - \`ca.der\`: (no password needed)
 
 ## Notes
-- The certificate is valid for 365 days from generation
+- The certificate is valid for 5 years (1825 days) from generation
 - Common name: Pixel 6
 - Used for mTLS authentication to localhost
 EOF

--- a/infrastructure/generate-certificates.sh
+++ b/infrastructure/generate-certificates.sh
@@ -17,7 +17,7 @@ function generate_client_cert() {
 	# Generate a key, CSR and certificate for the client
 	openssl genrsa -out "$client_name.key" 2048 2>/dev/null
 	openssl req -new -key "$client_name.key" -subj "/C=GB/ST=England/L=London/O=client/CN=$common_name" -addext "subjectAltName = DNS:localhost" -out "$client_name.csr" 2>/dev/null
-	openssl x509 -req -in "$client_name.csr" -CA ca.crt -CAkey ca.key -CAcreateserial -extfile <(printf "subjectAltName=DNS:localhost") -days 1825 -out "$client_name.crt" 2>/dev/null
+	openssl x509 -req -in "$client_name.csr" -CA ca.crt -CAkey ca.key -CAcreateserial -extfile <(printf "subjectAltName=DNS:localhost") -days 365 -out "$client_name.crt" 2>/dev/null
 
 	# Generate a PEM file for `curl` and a `p12` for browser usage
 	cat "$client_name.crt" "$client_name.key" > "$client_name.pem"
@@ -39,13 +39,13 @@ function generate_from_scratch() {
 	# Generate a key for the CA as well as a self-signed certificate
 	echo "Generating root CA..."
 	openssl genrsa -out ca.key 2048 2>/dev/null
-	openssl req -new -x509 -key ca.key -out ca.crt -subj "/C=GB/ST=England/L=London/O=root/CN=localhost" -days 1825 2>/dev/null
+	openssl req -new -x509 -key ca.key -out ca.crt -subj "/C=GB/ST=England/L=London/O=root/CN=localhost" 2>/dev/null
 
 	# Generate a key, CSR and certificate for the server
 	echo "Generating server certificate..."
 	openssl genrsa -out localhost.key 2048 2>/dev/null
 	openssl req -new -key localhost.key -subj "/C=GB/ST=England/L=London/O=server/CN=localhost" -addext "subjectAltName = DNS:localhost" -out localhost.csr 2>/dev/null
-	openssl x509 -req -in localhost.csr -CA ca.crt -CAkey ca.key -CAcreateserial -extfile <(printf "subjectAltName=DNS:localhost") -days 1825 -out localhost.crt 2>/dev/null
+	openssl x509 -req -in localhost.csr -CA ca.crt -CAkey ca.key -CAcreateserial -extfile <(printf "subjectAltName=DNS:localhost") -out localhost.crt 2>/dev/null
 
 	# Concatenate the certificates for the server to use
 	cat localhost.crt ca.crt > localhost.bundle.crt
@@ -117,16 +117,20 @@ function package_mobile() {
 	openssl x509 -outform der -in ca.crt -out dist/clients/mobile/android/ca.der 2>/dev/null
 
 	echo "Creating PKCS12 bundle with full certificate chain..."
+	# Create a full chain PEM (client cert + CA cert)
+	cat mobile.crt ca.crt > mobile.chain.pem
+	cat mobile.chain.pem mobile.key > mobile.full.pem
 
-	# Use homebrew OpenSSL 3 — LibreSSL (/usr/bin/openssl) defaults the PBKDF2 PRF to
-	# hmacWithSHA1 even with AES-256-CBC, which Android 14+ rejects. OpenSSL 3 defaults
-	# to hmacWithSHA256, producing a PKCS12 Android accepts.
-	/opt/homebrew/bin/openssl pkcs12 -export \
+	# Create PKCS12 with the full chain (with password for Android compatibility)
+	# Using AES-256-CBC and SHA256 for Android compatibility
+	/usr/bin/openssl pkcs12 -export \
 		-in mobile.crt \
 		-inkey mobile.key \
 		-certfile ca.crt \
 		-out dist/clients/mobile/android/mobile-with-ca.p12 \
 		-name "Pixel 6" \
+		-keypbe AES-256-CBC \
+		-certpbe AES-256-CBC \
 		-macalg sha256 \
 		-passout pass:password
 
@@ -164,7 +168,7 @@ function package_mobile() {
 - \`ca.der\`: (no password needed)
 
 ## Notes
-- The certificate is valid for 5 years (1825 days) from generation
+- The certificate is valid for 365 days from generation
 - Common name: Pixel 6
 - Used for mTLS authentication to localhost
 EOF


### PR DESCRIPTION
Now that `dns-server` is successfully producing metrics, it would be useful to be able to inspect the other applications and see how they're doing.

This change:
* Moves the metric handling to `foundation/metrics`
* Adds a counter for the responses and paths coming back from servers
