### PR TITLE
feat: cache negative responses

### DIFF
--- a/apps/dns-server/resources/sample-config.yaml
+++ b/apps/dns-server/resources/sample-config.yaml
@@ -28,3 +28,4 @@ blocklist:
 cache:
   max_entries: 10000
   default_ttl_seconds: 300
+  error_ttl_seconds: 60

--- a/apps/dns-server/src/cache.rs
+++ b/apps/dns-server/src/cache.rs
@@ -30,6 +30,7 @@ impl Expiry<String, Arc<CachedResponse>> for DnsExpiry {
 pub struct ResponseCache {
     cache: Cache<String, Arc<CachedResponse>>,
     default_ttl: Duration,
+    error_ttl: Duration,
 }
 
 impl ResponseCache {
@@ -40,14 +41,20 @@ impl ResponseCache {
             .build();
 
         let default_ttl = Duration::from_secs(config.default_ttl_seconds);
+        let error_ttl = Duration::from_secs(config.error_ttl_seconds);
 
         tracing::info!(
             max_entries = config.max_entries,
             default_ttl_seconds = config.default_ttl_seconds,
+            error_ttl_seconds = config.error_ttl_seconds,
             "initialized DNS response cache"
         );
 
-        Self { cache, default_ttl }
+        Self {
+            cache,
+            default_ttl,
+            error_ttl,
+        }
     }
 
     #[tracing::instrument(skip(self))]
@@ -76,6 +83,10 @@ impl ResponseCache {
         );
 
         self.cache.insert(key.to_string(), cached).await;
+    }
+
+    pub fn error_ttl(&self) -> Duration {
+        self.error_ttl
     }
 
     pub fn extract_ttl(message: &Message) -> Option<Duration> {

--- a/apps/dns-server/src/config.rs
+++ b/apps/dns-server/src/config.rs
@@ -49,6 +49,7 @@ pub struct BlocklistConfig {
 pub struct CacheConfig {
     pub max_entries: u64,
     pub default_ttl_seconds: u64,
+    pub error_ttl_seconds: u64,
 }
 
 #[cfg(test)]
@@ -101,6 +102,7 @@ mod tests {
             cache: CacheConfig {
                 max_entries: 10000,
                 default_ttl_seconds: 300,
+                error_ttl_seconds: 60,
             },
         };
 

--- a/apps/dns-server/src/handler.rs
+++ b/apps/dns-server/src/handler.rs
@@ -112,13 +112,20 @@ impl RequestHandler for DnsRequestHandler {
         let cache_key = format!("{}:{:?}", domain_name, request_info.query.query_type());
 
         if let Some(cached_response) = self.cache.get(&cache_key).await {
+            let is_negative = cached_response.metadata.response_code == ResponseCode::ServFail;
+            let type_label = if is_negative {
+                "negative-cache-hit"
+            } else {
+                "cache-hit"
+            };
             tracing::debug!(
                 name = %domain_name,
                 src = %request.src(),
+                negative = is_negative,
                 "returning cached response"
             );
 
-            let attrs = [KeyValue::new("type", "cache-hit")];
+            let attrs = [KeyValue::new("type", type_label)];
             self.metrics.responses.add(1, &attrs);
 
             let mut metadata = cached_response.metadata;
@@ -177,6 +184,9 @@ impl RequestHandler for DnsRequestHandler {
                 );
                 error_msg.metadata.response_code = ResponseCode::ServFail;
                 error_msg.add_query(request_info.query.original().clone());
+                self.cache
+                    .insert(&cache_key, error_msg.clone(), Some(self.cache.error_ttl()))
+                    .await;
                 (error_msg, "upstream-error")
             }
         };

--- a/infrastructure/configuration/dns-server/config.yaml
+++ b/infrastructure/configuration/dns-server/config.yaml
@@ -28,6 +28,7 @@ blocklist:
 cache:
   max_entries: 10000
   default_ttl_seconds: 300
+  error_ttl_seconds: 60
 
 metrics:
   endpoint: http://prometheus.mesh.internal/api/v1/otlp/v1/metrics


### PR DESCRIPTION
Due to Mullvad's blocking of certain domains (or failures to resolve IPv6 addresses), some responses might come back with a `ServFail` code. At the moment these aren't being cached like successful requests, so we're sending a lot more requests upstream than we probably need to.

This change:
* Caches the `ServFail` responses as well
* Adds the configuration for the TTL
