### PR TITLE
feat: support TCP proxying

### DIFF
--- a/apps/Cargo.lock
+++ b/apps/Cargo.lock
@@ -1788,6 +1788,7 @@ dependencies = [
  "serde_yaml",
  "tempfile",
  "tokio",
+ "tokio-rustls 0.26.4",
  "tracing",
  "tracing-subscriber",
  "urlencoding",
@@ -3040,6 +3041,10 @@ name = "integration-tests"
 version = "0.1.0"
 dependencies = [
  "color-eyre",
+ "rustls 0.23.40",
+ "rustls-pemfile",
+ "tokio",
+ "tokio-rustls 0.26.4",
  "ureq",
 ]
 

--- a/apps/f2/Cargo.toml
+++ b/apps/f2/Cargo.toml
@@ -32,6 +32,7 @@ serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.150"
 serde_yaml = "0.9.33"
 tokio = { version = "1.52.3", features = ["macros", "rt-multi-thread", "time", "fs", "signal"] }
+tokio-rustls = { version = "0.26.4", default-features = false, features = ["ring"] }
 tracing = "0.1.44"
 tracing-subscriber = { version = "0.3.23", features = ["env-filter"] }
 urlencoding = "2.1.3"

--- a/apps/f2/development/servers/tcp-echo/Dockerfile
+++ b/apps/f2/development/servers/tcp-echo/Dockerfile
@@ -1,0 +1,9 @@
+FROM python:3.9-slim
+
+WORKDIR /app
+
+COPY server.py ./
+
+EXPOSE 8080
+
+CMD ["python", "server.py"]

--- a/apps/f2/development/servers/tcp-echo/server.py
+++ b/apps/f2/development/servers/tcp-echo/server.py
@@ -1,0 +1,17 @@
+import socket
+import threading
+
+
+def handle(conn):
+    with conn:
+        while chunk := conn.recv(4096):
+            conn.sendall(chunk)
+
+
+with socket.socket() as s:
+    s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    s.bind(("0.0.0.0", 8080))
+    s.listen()
+    while True:
+        conn, _ = s.accept()
+        threading.Thread(target=handle, args=(conn,), daemon=True).start()

--- a/apps/f2/development/tcp-tls-config.yaml
+++ b/apps/f2/development/tcp-tls-config.yaml
@@ -1,0 +1,23 @@
+alb:
+  addr: 0.0.0.0
+  ports:
+    tls: 3001
+  reconciliation: /reconcile
+  tls:
+    domains:
+      old.example.com:
+        cert_file:
+          location: filesystem
+          path: /resources/certificates/old.crt
+        key_file:
+          location: filesystem
+          path: /resources/certificates/old.key
+
+services:
+  tcp-echo:
+    image: tcp-echo
+    tag: latest
+    replicas: 1
+    routes:
+      - host: old.example.com
+        port: 8080

--- a/apps/f2/development/tcp-tls-config.yaml
+++ b/apps/f2/development/tcp-tls-config.yaml
@@ -1,7 +1,7 @@
 alb:
   addr: 0.0.0.0
   ports:
-    tls: 3001
+    tls: 4001
   reconciliation: /reconcile
   tls:
     domains:

--- a/apps/f2/integration-tests/Cargo.toml
+++ b/apps/f2/integration-tests/Cargo.toml
@@ -5,4 +5,8 @@ edition = "2024"
 
 [dependencies]
 color-eyre = "0.6.5"
+rustls = { version = "0.23", default-features = false, features = ["ring", "std"] }
+rustls-pemfile = "2"
+tokio = { version = "1", features = ["rt", "net", "io-util"] }
+tokio-rustls = { version = "0.26", default-features = false, features = ["ring"] }
 ureq = "3.3.0"

--- a/apps/f2/integration-tests/src/docker.rs
+++ b/apps/f2/integration-tests/src/docker.rs
@@ -81,13 +81,20 @@ pub fn create_network_if_not_exists(network: &str) -> Result<()> {
 pub fn run(
     image: &str,
     version: &str,
-    volumes: &[(&'static str, &'static str)],
-    configuration_file: &'static str,
+    volumes: &[(&str, &str)],
+    configuration_file: &str,
+    ports: &[(&str, &str)],
 ) -> Result<String> {
     let tag = format!("{}:{}", image, version);
 
     let mut command = Command::new("docker");
-    command.arg("run").arg("-d").arg("-p").arg("3000:3000");
+    command.arg("run").arg("-d");
+
+    for (host_port, container_port) in ports {
+        command
+            .arg("-p")
+            .arg(format!("{}:{}", host_port, container_port));
+    }
 
     for (host_path, container_path) in volumes {
         command

--- a/apps/f2/integration-tests/src/main.rs
+++ b/apps/f2/integration-tests/src/main.rs
@@ -1,6 +1,13 @@
+use std::sync::Arc;
 use std::time::Duration;
 
 use color_eyre::eyre::{Context, Result, eyre};
+use rustls::client::danger::{HandshakeSignatureValid, ServerCertVerified, ServerCertVerifier};
+use rustls::pki_types::{CertificateDer, ServerName, UnixTime};
+use rustls::{DigitallySignedStruct, Error as TlsError, SignatureScheme};
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::TcpStream;
+use tokio_rustls::TlsConnector;
 
 mod docker;
 
@@ -18,6 +25,9 @@ fn main() -> Result<()> {
 
     // check that rolls work correctly
     check_rolls_work().wrap_err("Rolls did not work correctly")?;
+
+    // check that the TCP TLS proxy correctly forwards bytes after TLS termination
+    check_tls_tcp_proxy_works().wrap_err("TCP TLS proxy did not work correctly")?;
 
     Ok(())
 }
@@ -56,6 +66,13 @@ fn setup_dependencies() -> Result<()> {
         "latest",
     )?;
 
+    crate::docker::build(
+        "development/servers/tcp-echo/Dockerfile",
+        "development/servers/tcp-echo",
+        "tcp-echo",
+        "latest",
+    )?;
+
     // create the internal network
     crate::docker::create_network_if_not_exists("internal")?;
 
@@ -69,7 +86,13 @@ fn check_volumes_work() -> Result<()> {
         ("/var/run/docker.sock", "/var/run/docker.sock"),
     ];
 
-    crate::docker::run("f2", "debug", &volumes, "/development/volumes-config.yaml")?;
+    crate::docker::run(
+        "f2",
+        "debug",
+        &volumes,
+        "/development/volumes-config.yaml",
+        &[("3000", "3000")],
+    )?;
 
     // give the container a moment to start up
     std::thread::sleep(Duration::from_secs(1));
@@ -97,6 +120,7 @@ fn check_rolls_work() -> Result<()> {
         "debug",
         &volumes,
         "/development/echo-single-config.yaml",
+        &[("3000", "3000")],
     )?;
 
     // give the container a moment to start up
@@ -149,6 +173,7 @@ fn check_args_work() -> Result<()> {
         "debug",
         &volumes,
         "/development/args-default-config.yaml",
+        &[("3000", "3000")],
     )?;
     std::thread::sleep(Duration::from_secs(1));
     assert_response_equals("http://localhost:3000", "default")?;
@@ -160,9 +185,110 @@ fn check_args_work() -> Result<()> {
         "debug",
         &volumes,
         "/development/args-override-config.yaml",
+        &[("3000", "3000")],
     )?;
     std::thread::sleep(Duration::from_secs(1));
     assert_response_equals("http://localhost:3000", "overridden")?;
+    crate::docker::remove_running_containers()?;
+
+    Ok(())
+}
+
+/// A TLS certificate verifier that accepts any certificate, for use in integration tests only.
+#[derive(Debug)]
+struct AcceptAnyCert;
+
+impl ServerCertVerifier for AcceptAnyCert {
+    fn verify_server_cert(
+        &self,
+        _end_entity: &CertificateDer<'_>,
+        _intermediates: &[CertificateDer<'_>],
+        _server_name: &ServerName<'_>,
+        _ocsp_response: &[u8],
+        _now: UnixTime,
+    ) -> std::result::Result<ServerCertVerified, TlsError> {
+        Ok(ServerCertVerified::assertion())
+    }
+
+    fn verify_tls12_signature(
+        &self,
+        message: &[u8],
+        cert: &CertificateDer<'_>,
+        dsa: &DigitallySignedStruct,
+    ) -> std::result::Result<HandshakeSignatureValid, TlsError> {
+        rustls::crypto::verify_tls12_signature(
+            message,
+            cert,
+            dsa,
+            &rustls::crypto::ring::default_provider().signature_verification_algorithms,
+        )
+    }
+
+    fn verify_tls13_signature(
+        &self,
+        message: &[u8],
+        cert: &CertificateDer<'_>,
+        dsa: &DigitallySignedStruct,
+    ) -> std::result::Result<HandshakeSignatureValid, TlsError> {
+        rustls::crypto::verify_tls13_signature(
+            message,
+            cert,
+            dsa,
+            &rustls::crypto::ring::default_provider().signature_verification_algorithms,
+        )
+    }
+
+    fn supported_verify_schemes(&self) -> Vec<SignatureScheme> {
+        rustls::crypto::ring::default_provider()
+            .signature_verification_algorithms
+            .supported_schemes()
+    }
+}
+
+fn check_tls_tcp_proxy_works() -> Result<()> {
+    let volumes = vec![
+        ("./development", "/development"),
+        ("./resources", "/resources"),
+        ("/var/run/docker.sock", "/var/run/docker.sock"),
+    ];
+
+    crate::docker::run(
+        "f2",
+        "debug",
+        &volumes,
+        "/development/tcp-tls-config.yaml",
+        &[("3001", "3001")],
+    )?;
+
+    std::thread::sleep(Duration::from_secs(1));
+
+    tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()?
+        .block_on(async {
+            let client_config = rustls::ClientConfig::builder()
+                .dangerous()
+                .with_custom_certificate_verifier(Arc::new(AcceptAnyCert))
+                .with_no_client_auth();
+
+            let connector = TlsConnector::from(Arc::new(client_config));
+            let stream = TcpStream::connect("127.0.0.1:3001").await?;
+            let domain = ServerName::try_from("old.example.com")?;
+            let mut tls = connector.connect(domain, stream).await?;
+
+            tls.write_all(b"hello").await?;
+            tls.flush().await?;
+
+            let mut buf = [0u8; 5];
+            tls.read_exact(&mut buf).await?;
+
+            assert_eq!(&buf, b"hello", "TCP TLS proxy did not echo bytes correctly");
+
+            color_eyre::eyre::Ok(())
+        })?;
+
+    println!("✅ TCP TLS proxy forwarded bytes correctly");
+
     crate::docker::remove_running_containers()?;
 
     Ok(())

--- a/apps/f2/integration-tests/src/main.rs
+++ b/apps/f2/integration-tests/src/main.rs
@@ -23,11 +23,12 @@ fn main() -> Result<()> {
     // (must run before check_rolls_work, whose reconciler prunes all unused images)
     check_args_work().wrap_err("Args did not work correctly")?;
 
+    // check that the TCP TLS proxy correctly forwards bytes after TLS termination
+    // (must run before check_rolls_work, whose reconciler prunes all unused images)
+    check_tls_tcp_proxy_works().wrap_err("TCP TLS proxy did not work correctly")?;
+
     // check that rolls work correctly
     check_rolls_work().wrap_err("Rolls did not work correctly")?;
-
-    // check that the TCP TLS proxy correctly forwards bytes after TLS termination
-    check_tls_tcp_proxy_works().wrap_err("TCP TLS proxy did not work correctly")?;
 
     Ok(())
 }
@@ -257,7 +258,7 @@ fn check_tls_tcp_proxy_works() -> Result<()> {
         "debug",
         &volumes,
         "/development/tcp-tls-config.yaml",
-        &[("3001", "3001")],
+        &[("4001", "4001")],
     )?;
 
     std::thread::sleep(Duration::from_secs(1));
@@ -272,7 +273,7 @@ fn check_tls_tcp_proxy_works() -> Result<()> {
                 .with_no_client_auth();
 
             let connector = TlsConnector::from(Arc::new(client_config));
-            let stream = TcpStream::connect("127.0.0.1:3001").await?;
+            let stream = TcpStream::connect("127.0.0.1:4001").await?;
             let domain = ServerName::try_from("old.example.com")?;
             let mut tls = connector.connect(domain, stream).await?;
 

--- a/apps/f2/src/config.rs
+++ b/apps/f2/src/config.rs
@@ -104,6 +104,7 @@ impl Config {
 pub enum Scheme {
     Http,
     Https,
+    Tls,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq, Deserialize)]

--- a/apps/f2/src/load_balancer/mod.rs
+++ b/apps/f2/src/load_balancer/mod.rs
@@ -18,10 +18,12 @@ use rand::prelude::SmallRng;
 use rustls::server::danger::ClientCertVerifier;
 use rustls::server::{NoClientAuth, WebPkiClientVerifier};
 use rustls::RootCertStore;
+use tcp::TcpTlsProxy;
 use tls::DynamicAuthenticationLevelResolver;
 use tokio::net::TcpListener;
 use tokio::sync::{Mutex, RwLock};
 use tokio::task::JoinSet;
+use tokio_rustls::TlsAcceptor;
 
 use crate::config::{Config, MtlsConfig, Scheme, TlsConfig};
 use crate::ipc::MessageBus;
@@ -29,6 +31,7 @@ use crate::load_balancer::tls::CertificateResolver;
 use crate::service_registry::ServiceRegistry;
 
 mod proxy;
+mod tcp;
 mod tls;
 
 #[derive(Debug)]
@@ -66,6 +69,12 @@ impl LoadBalancer {
     ) -> Result<()> {
         let reconciliation_path = Arc::from(self.config.load().alb.reconciliation.as_str());
         let message_bus = Arc::clone(&self.message_bus);
+
+        // Pre-clone Arcs needed after `service_factory` moves `self`
+        let service_registry = Arc::clone(&self.service_registry);
+        let rng = Arc::clone(&self.rng);
+        let self_config = Arc::clone(&self.config);
+        let self_message_bus = Arc::clone(&self.message_bus);
 
         let service_factory = move |_| {
             let service_registry = Arc::clone(&self.service_registry);
@@ -106,7 +115,7 @@ impl LoadBalancer {
         }
 
         if let Some(listener) = listeners.remove(&Scheme::Https) {
-            if let Some(tls) = tls {
+            if let Some(tls) = tls.as_ref() {
                 let client_cert_verifier: Arc<dyn ClientCertVerifier> = match &mtls {
                     Some(config) => {
                         let bytes = config.anchor.resolve().await?;
@@ -123,13 +132,13 @@ impl LoadBalancer {
                     None => Arc::new(NoClientAuth),
                 };
 
-                let config = Arc::new(tls.domains);
-                let message_bus = Arc::clone(&self.message_bus);
+                let config = Arc::new(tls.domains.clone());
 
-                let certificate_resolver =
-                    Arc::new(CertificateResolver::new(config, message_bus).await?);
+                let certificate_resolver = Arc::new(
+                    CertificateResolver::new(config, Arc::clone(&self_message_bus)).await?,
+                );
                 let authentication_level_resolver =
-                    DynamicAuthenticationLevelResolver::new(Arc::clone(&self.config));
+                    DynamicAuthenticationLevelResolver::new(Arc::clone(&self_config));
 
                 let server_configuration = ServerConfiguration::default();
                 let server = Server::new(
@@ -143,6 +152,27 @@ impl LoadBalancer {
                 tracing::info!("starting https server on {}", listener.local_addr()?);
 
                 tasks.spawn(server.run(listener));
+            }
+        }
+
+        if let Some(listener) = listeners.remove(&Scheme::Tls) {
+            if let Some(tls) = tls.as_ref() {
+                let config = Arc::new(tls.domains.clone());
+                let certificate_resolver = Arc::new(
+                    CertificateResolver::new(config, Arc::clone(&self_message_bus)).await?,
+                );
+
+                let server_config = rustls::ServerConfig::builder()
+                    .with_no_client_auth()
+                    .with_cert_resolver(certificate_resolver);
+
+                let acceptor = TlsAcceptor::from(Arc::new(server_config));
+                let proxy =
+                    TcpTlsProxy::new(Arc::clone(&service_registry), Arc::clone(&rng), acceptor);
+
+                tracing::info!("starting TCP TLS proxy on {}", listener.local_addr()?);
+
+                tasks.spawn(proxy.run(listener));
             }
         }
 

--- a/apps/f2/src/load_balancer/tcp.rs
+++ b/apps/f2/src/load_balancer/tcp.rs
@@ -1,0 +1,96 @@
+use std::net::SocketAddrV4;
+use std::sync::Arc;
+
+use color_eyre::eyre::{eyre, Result};
+use rand::prelude::SmallRng;
+use rand::Rng;
+use tokio::io::copy_bidirectional;
+use tokio::net::{TcpListener, TcpStream};
+use tokio::sync::{Mutex, RwLock};
+use tokio_rustls::TlsAcceptor;
+
+use crate::service_registry::ServiceRegistry;
+
+pub struct TcpTlsProxy {
+    service_registry: Arc<RwLock<ServiceRegistry>>,
+    rng: Arc<Mutex<SmallRng>>,
+    acceptor: TlsAcceptor,
+}
+
+impl TcpTlsProxy {
+    pub fn new(
+        service_registry: Arc<RwLock<ServiceRegistry>>,
+        rng: Arc<Mutex<SmallRng>>,
+        acceptor: TlsAcceptor,
+    ) -> Self {
+        Self {
+            service_registry,
+            rng,
+            acceptor,
+        }
+    }
+
+    pub async fn run(self, mut listener: TcpListener) {
+        loop {
+            if let Err(e) = self.try_handle_connection(&mut listener).await {
+                tracing::warn!(%e, "failed to handle TCP TLS connection");
+            }
+        }
+    }
+
+    async fn try_handle_connection(&self, listener: &mut TcpListener) -> Result<()> {
+        let (stream, peer_addr) = listener.accept().await?;
+
+        let acceptor = self.acceptor.clone();
+        let service_registry = Arc::clone(&self.service_registry);
+        let rng = Arc::clone(&self.rng);
+
+        tokio::spawn(async move {
+            if let Err(e) = handle_connection(acceptor, service_registry, rng, stream).await {
+                tracing::warn!(%peer_addr, %e, "error handling TCP TLS connection");
+            }
+        });
+
+        Ok(())
+    }
+}
+
+async fn handle_connection(
+    acceptor: TlsAcceptor,
+    service_registry: Arc<RwLock<ServiceRegistry>>,
+    rng: Arc<Mutex<SmallRng>>,
+    stream: TcpStream,
+) -> Result<()> {
+    let mut tls_stream = acceptor.accept(stream).await?;
+
+    let sni = tls_stream
+        .get_ref()
+        .1
+        .server_name()
+        .ok_or_else(|| eyre!("no SNI hostname in TLS handshake"))?
+        .to_owned();
+
+    let read_lock = service_registry.read().await;
+
+    let Some((downstreams, port)) = read_lock.find_downstreams(&sni, "") else {
+        return Err(eyre!("no downstream found for SNI hostname {sni}"));
+    };
+
+    let downstream_addr = {
+        let mut rng = rng.lock().await;
+        let idx = rng.next_u32() as usize % downstreams.len();
+        downstreams
+            .get_index(idx)
+            .ok_or_else(|| eyre!("no downstream available for {sni}"))?
+            .addr
+    };
+
+    drop(read_lock);
+
+    let addr = SocketAddrV4::new(downstream_addr, port);
+    let mut backend = TcpStream::connect(addr).await?;
+
+    copy_bidirectional(&mut tls_stream, &mut backend).await?;
+
+    Ok(())
+}


### PR DESCRIPTION
`dns-server` currently runs on an instance without `f2` as the latter doesn't support TCP proxying, but it would be nice to be able to deploy changes to it automatically instead of SSHing in.

This change:
* Adds support for TCP proxying, with TLS termination within `f2` still
