### PR TITLE
feat: start supporting scheduled jobs

### DIFF
--- a/apps/certmanager/src/watcher.rs
+++ b/apps/certmanager/src/watcher.rs
@@ -1,7 +1,7 @@
 use std::time::Duration;
 
 use color_eyre::eyre::Result;
-use foundation_recurring_job::Job;
+use foundation_recurring_job::{Job, Schedule};
 use sqlx::PgPool;
 use sqlx::types::chrono::Utc;
 
@@ -21,8 +21,8 @@ impl Watcher {
 impl Job for Watcher {
     const NAME: &'static str = "Certificate Expiry Watcher";
 
-    fn interval(&self) -> Duration {
-        Duration::from_hours(1)
+    fn schedule(&self) -> Schedule {
+        Schedule::interval(Duration::from_hours(1))
     }
 
     async fn run(&self) -> Result<()> {

--- a/apps/dns-server/src/blocklist.rs
+++ b/apps/dns-server/src/blocklist.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use color_eyre::eyre::{Context, Result};
-use foundation_recurring_job::Job;
+use foundation_recurring_job::{Job, Schedule};
 use tokio::sync::RwLock;
 
 use crate::config::BlocklistConfig;
@@ -92,8 +92,10 @@ impl BlocklistManager {
 impl Job for BlocklistManager {
     const NAME: &'static str = "blocklist-manager";
 
-    fn interval(&self) -> Duration {
-        Duration::from_secs(self.config.refresh_interval_seconds)
+    fn schedule(&self) -> Schedule {
+        let duration = Duration::from_secs(self.config.refresh_interval_seconds);
+
+        Schedule::interval(duration)
     }
 
     async fn run(&self) -> Result<()> {

--- a/apps/foundation/recurring-job/src/lib.rs
+++ b/apps/foundation/recurring-job/src/lib.rs
@@ -4,11 +4,26 @@ use std::time::Duration;
 use color_eyre::eyre::Result;
 use foundation_shutdown::{CancellationToken, GracefulTask};
 
+pub enum Schedule {
+    Interval(Duration),
+    Daily { hour: u32, minute: u32 },
+}
+
+impl Schedule {
+    pub fn interval(duration: Duration) -> Self {
+        Schedule::Interval(duration)
+    }
+
+    pub fn daily(hour: u32, minute: u32) -> Self {
+        Schedule::Daily { hour, minute }
+    }
+}
+
 pub trait Job: Send + 'static {
     const NAME: &'static str;
 
     fn run(&self) -> impl Future<Output = Result<()>> + Send + '_;
-    fn interval(&self) -> Duration;
+    fn schedule(&self) -> Schedule;
 }
 
 pub struct RecurringJob<T>
@@ -26,7 +41,11 @@ impl<T: Job> RecurringJob<T> {
 
 impl<T: Job> GracefulTask for RecurringJob<T> {
     async fn run_until_shutdown(self, shutdown: CancellationToken) -> Result<()> {
-        let mut interval = tokio::time::interval(self.state.interval());
+        let Schedule::Interval(duration) = self.state.schedule() else {
+            unimplemented!("only interval scheduling is supported for now");
+        };
+
+        let mut interval = tokio::time::interval(duration);
         let job = T::NAME;
 
         loop {
@@ -59,7 +78,7 @@ mod tests {
     use tokio::sync::Mutex;
     use tokio::sync::mpsc::{Receiver, Sender};
 
-    use crate::{Job, RecurringJob};
+    use crate::{Job, RecurringJob, Schedule};
 
     struct TestJob {
         counter: Arc<AtomicUsize>,
@@ -70,8 +89,8 @@ mod tests {
     impl Job for TestJob {
         const NAME: &'static str = "test-job";
 
-        fn interval(&self) -> Duration {
-            Duration::from_millis(1)
+        fn schedule(&self) -> Schedule {
+            Schedule::Interval(Duration::from_millis(1))
         }
 
         fn run(&self) -> impl Future<Output = Result<()>> + Send + '_ {

--- a/apps/uptime/src/certificate_checker/mod.rs
+++ b/apps/uptime/src/certificate_checker/mod.rs
@@ -2,7 +2,7 @@ use std::time::Duration;
 
 use chrono::Utc;
 use color_eyre::eyre::Result;
-use foundation_recurring_job::Job;
+use foundation_recurring_job::{Job, Schedule};
 use reqwest::Client;
 use sqlx::PgPool;
 use tracing::{error, info};
@@ -25,8 +25,8 @@ impl CertificateChecker {
 impl Job for CertificateChecker {
     const NAME: &'static str = "Certificate Checker";
 
-    fn interval(&self) -> Duration {
-        Duration::from_hours(24)
+    fn schedule(&self) -> Schedule {
+        Schedule::Interval(Duration::from_hours(24))
     }
 
     async fn run(&self) -> Result<()> {

--- a/apps/uptime/src/poller/mod.rs
+++ b/apps/uptime/src/poller/mod.rs
@@ -2,7 +2,7 @@ use std::fmt::{self, Display};
 use std::time::Duration;
 
 use color_eyre::eyre::Result;
-use foundation_recurring_job::Job;
+use foundation_recurring_job::{Job, Schedule};
 use sqlx::PgPool;
 use sqlx::types::chrono::Utc;
 use uuid::Uuid;
@@ -298,8 +298,8 @@ impl<N: Notifier> Poller<N> {
 impl<N: Notifier + Send + Sync + 'static> Job for Poller<N> {
     const NAME: &'static str = "Origin Poller";
 
-    fn interval(&self) -> Duration {
-        Duration::from_secs(60)
+    fn schedule(&self) -> Schedule {
+        Schedule::interval(Duration::from_secs(60))
     }
 
     async fn run(&self) -> Result<()> {


### PR DESCRIPTION
Currently, recurring jobs must just run on a given interval which is not very flexible. This means that `pgmanager` for example cannot use them, as it runs backups at a specific time every day.

This change:
* Begins abstracting schedules into interval-based and time-based
