### PR TITLE
feat: support daily jobs

### DIFF
--- a/apps/Cargo.lock
+++ b/apps/Cargo.lock
@@ -1944,8 +1944,10 @@ dependencies = [
 name = "foundation-recurring-job"
 version = "0.1.0"
 dependencies = [
+ "chrono",
  "color-eyre",
  "foundation-shutdown",
+ "test-case",
  "tokio",
  "tracing",
 ]
@@ -5267,6 +5269,39 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38ea62bd58771b570262e11ffa274fa9eda9986bd886e6e3a1f7f42afef8024c"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "test-case"
+version = "3.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb2550dd13afcd286853192af8601920d959b14c401fcece38071d53bf0768a8"
+dependencies = [
+ "test-case-macros",
+]
+
+[[package]]
+name = "test-case-core"
+version = "3.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "adcb7fd841cd518e279be3d5a3eb0636409487998a4aff22f3de87b81e88384f"
+dependencies = [
+ "cfg-if",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "test-case-macros"
+version = "3.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c89e72a01ed4c579669add59014b9a524d609c0c88c6a585ce37485879f6ffb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "test-case-core",
 ]
 
 [[package]]

--- a/apps/foundation/recurring-job/Cargo.toml
+++ b/apps/foundation/recurring-job/Cargo.toml
@@ -4,10 +4,12 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
+chrono = "0.4.45"
 color-eyre = "0.6.5"
 foundation-shutdown = { path = "../shutdown" }
 tokio = { version = "1.48.0", default-features = false, features = ["macros", "time"] }
 tracing.workspace = true
 
 [dev-dependencies]
+test-case = "3.3.1"
 tokio = { version = "1.48.0", default-features = false, features = ["macros", "rt", "test-util", "time"] }

--- a/apps/foundation/recurring-job/src/lib.rs
+++ b/apps/foundation/recurring-job/src/lib.rs
@@ -1,7 +1,8 @@
 use std::future::Future;
 use std::time::Duration;
 
-use color_eyre::eyre::Result;
+use chrono::{DateTime, TimeZone, Utc};
+use color_eyre::eyre::{Result, eyre};
 use foundation_shutdown::{CancellationToken, GracefulTask};
 
 #[derive(Copy, Clone, Debug)]
@@ -40,13 +41,9 @@ impl<T: Job> RecurringJob<T> {
     }
 }
 
-impl<T: Job> GracefulTask for RecurringJob<T> {
-    async fn run_until_shutdown(self, shutdown: CancellationToken) -> Result<()> {
-        let Schedule::Interval(duration) = self.state.schedule() else {
-            unimplemented!("only interval scheduling is supported for now");
-        };
-
-        let mut interval = tokio::time::interval(duration);
+impl<T: Job> RecurringJob<T> {
+    async fn run_interval_job(self, interval: Duration, shutdown: CancellationToken) -> Result<()> {
+        let mut interval = tokio::time::interval(interval);
         let job = T::NAME;
 
         loop {
@@ -65,6 +62,92 @@ impl<T: Job> GracefulTask for RecurringJob<T> {
 
         Ok(())
     }
+
+    async fn run_daily_job(
+        self,
+        hour: u32,
+        minute: u32,
+        shutdown: CancellationToken,
+    ) -> Result<()> {
+        let job = T::NAME;
+
+        loop {
+            let now = Utc::now();
+            let sleep_duration = calculate_sleep_duration(now, hour, minute)?;
+
+            tracing::info!(%job, ?sleep_duration, "waiting until next scheduled run");
+
+            tokio::select! {
+                _ = shutdown.cancelled() => {
+                    tracing::info!(%job, "shutting down gracefully");
+                    break;
+                }
+                _ = tokio::time::sleep(sleep_duration) => {
+                    if let Err(e) = self.state.run().await {
+                        tracing::warn!(%job, error = ?e, "job execution failed");
+                    }
+                }
+            }
+        }
+
+        Ok(())
+    }
+}
+
+impl<T: Job> GracefulTask for RecurringJob<T> {
+    async fn run_until_shutdown(self, shutdown: CancellationToken) -> Result<()> {
+        match self.state.schedule() {
+            Schedule::Interval(duration) => {
+                tracing::info!(job = T::NAME, ?duration, "starting recurring job");
+                self.run_interval_job(duration, shutdown).await
+            }
+            Schedule::Daily { hour, minute } => {
+                tracing::info!(job = T::NAME, ?hour, ?minute, "starting recurring job");
+                self.run_daily_job(hour, minute, shutdown).await
+            }
+        }
+    }
+}
+
+fn calculate_next_run(
+    now: DateTime<Utc>,
+    target_hour: u32,
+    target_minute: u32,
+) -> Result<DateTime<Utc>> {
+    let current_date = now.date_naive();
+    let target_time = current_date
+        .and_hms_opt(target_hour, target_minute, 0)
+        .ok_or_else(|| eyre!("Invalid target hour or minute"))?;
+
+    // If the target time has already passed today, schedule for tomorrow
+    let next_run = if now.naive_utc() >= target_time {
+        current_date
+            .succ_opt()
+            .ok_or_else(|| eyre!("Failed to calculate next day"))?
+            .and_hms_opt(target_hour, target_minute, 0)
+            .ok_or_else(|| eyre!("Invalid target hour or minute for next day"))?
+    } else {
+        target_time
+    };
+
+    let next_run_utc = Utc
+        .from_local_datetime(&next_run)
+        .single()
+        .ok_or_else(|| eyre!("Failed to convert next run time to UTC"))?;
+
+    Ok(next_run_utc)
+}
+
+fn calculate_sleep_duration(
+    now: DateTime<Utc>,
+    target_hour: u32,
+    target_minute: u32,
+) -> Result<Duration> {
+    let next_run = calculate_next_run(now, target_hour, target_minute)?;
+    let duration_until_next_run = next_run - now;
+    let duration_until_next_run = duration_until_next_run.to_std().unwrap_or_default();
+
+    Ok(duration_until_next_run)
 }
 
 #[cfg(test)]
@@ -74,8 +157,10 @@ mod tests {
     use std::sync::atomic::{AtomicU32, Ordering};
     use std::time::Duration;
 
+    use chrono::{DateTime, Utc};
     use color_eyre::eyre::Result;
     use foundation_shutdown::{CancellationToken, GracefulTask};
+    use test_case::test_case;
 
     use crate::{Job, RecurringJob, Schedule};
 
@@ -101,7 +186,7 @@ mod tests {
     }
 
     #[tokio::test(start_paused = true)]
-    async fn can_create_and_run_recurring_job() {
+    async fn can_handle_scheduled_jobs() -> Result<()> {
         let counter = Arc::new(AtomicU32::new(0));
 
         let interval = Duration::from_millis(1);
@@ -117,9 +202,7 @@ mod tests {
         let shutdown_token = CancellationToken::new();
         let job_token = shutdown_token.clone();
 
-        tokio::spawn(async move {
-            job.run_until_shutdown(job_token).await.unwrap();
-        });
+        let handle = tokio::spawn(async move { job.run_until_shutdown(job_token).await });
 
         // advance time to allow the job to run a few times
         let iterations = 3;
@@ -128,5 +211,74 @@ mod tests {
         assert_eq!(counter.load(Ordering::SeqCst), iterations);
 
         shutdown_token.cancel();
+
+        handle.await??;
+
+        Ok(())
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn can_handle_daily_jobs() -> Result<()> {
+        let counter = Arc::new(AtomicU32::new(0));
+
+        let schedule = Schedule::daily(9, 0);
+
+        let job = TestJob {
+            counter: counter.clone(),
+            schedule,
+        };
+
+        let job = RecurringJob::new(job);
+
+        let shutdown_token = CancellationToken::new();
+        let job_token = shutdown_token.clone();
+
+        let handle = tokio::spawn(async move { job.run_until_shutdown(job_token).await });
+
+        // advance time to allow the job to run
+        let sleep_duration = crate::calculate_sleep_duration(Utc::now(), 9, 0)?;
+        tokio::time::sleep(sleep_duration + Duration::from_millis(1)).await;
+
+        assert_eq!(counter.load(Ordering::SeqCst), 1);
+
+        shutdown_token.cancel();
+
+        handle.await??;
+
+        Ok(())
+    }
+
+    fn datetime(date: &str, time: &str) -> DateTime<Utc> {
+        let datetime_str = format!("{} {} +0000", date, time);
+
+        DateTime::parse_from_str(&datetime_str, "%d/%m/%Y %H:%M %z")
+            .expect("Failed to parse date and time")
+            .with_timezone(&Utc)
+    }
+
+    fn time(time: &str) -> (u32, u32) {
+        let parts: Vec<&str> = time.split(':').collect();
+
+        let hour = parts[0].parse::<u32>().expect("Failed to parse hour");
+        let minute = parts[1].parse::<u32>().expect("Failed to parse minute");
+
+        (hour, minute)
+    }
+
+    #[test_case(datetime("01/06/2026", "08:00"), datetime("01/06/2026", "09:00"), time("09:00"); "before scheduled time")]
+    #[test_case(datetime("01/06/2026", "08:59"), datetime("01/06/2026", "09:00"), time("09:00"); "just before scheduled time")]
+    #[test_case(datetime("01/06/2026", "09:01"), datetime("02/06/2026", "09:00"), time("09:00"); "just after scheduled time")]
+    #[test_case(datetime("01/06/2026", "10:00"), datetime("02/06/2026", "09:00"), time("09:00"); "after scheduled time")]
+    fn can_calculate_next_run(
+        now: DateTime<Utc>,
+        expected: DateTime<Utc>,
+        scheduled_time: (u32, u32),
+    ) {
+        let (scheduled_hour, scheduled_minute) = scheduled_time;
+
+        let next_run = crate::calculate_next_run(now, scheduled_hour, scheduled_minute)
+            .expect("Failed to calculate next run time");
+
+        assert_eq!(next_run, expected);
     }
 }


### PR DESCRIPTION
Some jobs will want to run on a schedule (such as every 5 minutes) whereas others will want to run at a particular time each day (such as 10pm when the traffic is lower).

This change:
* Adds support for daily jobs
* Adds tests to make sure it works
