### PR TITLE
refactor: remove redundant method

### DIFF
--- a/apps/dns-server/src/blocklist.rs
+++ b/apps/dns-server/src/blocklist.rs
@@ -126,17 +126,11 @@ impl Job for BlocklistManager {
     }
 }
 
-impl BlocklistManager {
-    #[tracing::instrument(skip(self))]
-    pub async fn is_blocked(&self, domain: &str) -> bool {
-        self.blocklist.read().await.is_blocked(domain)
-    }
-}
-
 #[async_trait::async_trait]
 impl BlocklistSource for BlocklistManager {
+    #[tracing::instrument(skip(self))]
     async fn is_blocked(&self, domain: &str) -> bool {
-        self.is_blocked(domain).await
+        self.blocklist.read().await.is_blocked(domain)
     }
 }
 


### PR DESCRIPTION
These methods have the same definition but one is for the implementation of `BlocklistSource`.

This change:
* Inlines one of them
