### PR TITLE
feat: abstract blocklist resolution

### DIFF
--- a/apps/dns-server/src/blocklist.rs
+++ b/apps/dns-server/src/blocklist.rs
@@ -3,22 +3,21 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use color_eyre::eyre::{Context, Result};
+use foundation_configuration::ExternalBytes;
 use foundation_recurring_job::{Job, Schedule};
 use tokio::sync::RwLock;
 
-use crate::config::BlocklistConfig;
-
 #[async_trait::async_trait]
-pub trait BlocklistSource: Send + Sync + Unpin {
+pub trait Blocklist: Send + Sync + Unpin {
     async fn is_blocked(&self, domain: &str) -> bool;
 }
 
 #[derive(Clone, Debug, Default)]
-struct Blocklist {
+pub struct StaticBlocklist {
     domains: HashSet<String>,
 }
 
-impl Blocklist {
+impl StaticBlocklist {
     fn new(domains: HashSet<String>) -> Self {
         Self { domains }
     }
@@ -70,18 +69,51 @@ impl Blocklist {
     }
 }
 
-/// Manages domain blocklist loaded from external source
-#[derive(Clone)]
-pub struct BlocklistManager {
-    config: BlocklistConfig,
-    blocklist: Arc<RwLock<Blocklist>>,
+#[async_trait::async_trait]
+pub trait BlocklistResolver: Send + Sync + Unpin {
+    async fn resolve(&self) -> Result<StaticBlocklist>;
 }
 
-impl BlocklistManager {
+#[derive(Clone)]
+pub struct ExternalBytesBlocklistResolver {
+    source: ExternalBytes,
+}
+
+impl ExternalBytesBlocklistResolver {
+    pub fn new(source: ExternalBytes) -> Self {
+        Self { source }
+    }
+}
+
+#[async_trait::async_trait]
+impl BlocklistResolver for ExternalBytesBlocklistResolver {
+    async fn resolve(&self) -> Result<StaticBlocklist> {
+        let data = self
+            .source
+            .resolve()
+            .await
+            .wrap_err("failed to load blocklist")?;
+
+        let content = std::str::from_utf8(&data).wrap_err("blocklist is not valid UTF-8")?;
+
+        Ok(StaticBlocklist::parse(content))
+    }
+}
+
+/// Manages domain blocklist loaded from external source
+#[derive(Clone)]
+pub struct BlocklistManager<R: BlocklistResolver = ExternalBytesBlocklistResolver> {
+    interval: Duration,
+    resolver: R,
+    blocklist: Arc<RwLock<StaticBlocklist>>,
+}
+
+impl<R: BlocklistResolver> BlocklistManager<R> {
     /// Create a new blocklist manager
-    pub async fn new(config: BlocklistConfig) -> Result<Self> {
+    pub async fn new(interval: Duration, resolver: R) -> Result<Self> {
         let manager = Self {
-            config,
+            interval,
+            resolver,
             blocklist: Default::default(),
         };
 
@@ -93,28 +125,13 @@ impl Job for BlocklistManager {
     const NAME: &'static str = "blocklist-manager";
 
     fn schedule(&self) -> Schedule {
-        let duration = Duration::from_secs(self.config.refresh_interval_seconds);
-
-        Schedule::interval(duration)
+        Schedule::interval(self.interval)
     }
 
     async fn run(&self) -> Result<()> {
-        tracing::info!(
-            source = ?self.config.source,
-            "refreshing blocklist"
-        );
+        tracing::info!("refreshing blocklist");
 
-        // Load blocklist from external source
-        let data = self
-            .config
-            .source
-            .resolve()
-            .await
-            .wrap_err("failed to load blocklist")?;
-
-        let content = str::from_utf8(&data).wrap_err("blocklist is not valid UTF-8")?;
-
-        let blocklist = Blocklist::parse(content);
+        let blocklist = self.resolver.resolve().await?;
         let count = blocklist.domains.len();
 
         // Update the blocklist atomically
@@ -127,7 +144,7 @@ impl Job for BlocklistManager {
 }
 
 #[async_trait::async_trait]
-impl BlocklistSource for BlocklistManager {
+impl Blocklist for BlocklistManager {
     #[tracing::instrument(skip(self))]
     async fn is_blocked(&self, domain: &str) -> bool {
         self.blocklist.read().await.is_blocked(domain)
@@ -138,11 +155,11 @@ impl BlocklistSource for BlocklistManager {
 mod tests {
     use std::collections::HashSet;
 
-    use crate::blocklist::Blocklist;
+    use crate::blocklist::StaticBlocklist;
 
     #[test]
     fn empty_blocklist_allows_domains() {
-        let blocklist = Blocklist::default();
+        let blocklist = StaticBlocklist::default();
 
         assert!(!blocklist.is_blocked("example.com"));
         assert!(!blocklist.is_blocked("sub.example.com"));
@@ -153,7 +170,7 @@ mod tests {
         let mut domains = HashSet::new();
         domains.insert("example.com".to_string());
 
-        let blocklist = Blocklist::new(domains);
+        let blocklist = StaticBlocklist::new(domains);
 
         assert!(blocklist.is_blocked("example.com"));
     }
@@ -163,7 +180,7 @@ mod tests {
         let mut domains = HashSet::new();
         domains.insert("example.com".to_string());
 
-        let blocklist = Blocklist::new(domains);
+        let blocklist = StaticBlocklist::new(domains);
 
         assert!(blocklist.is_blocked("sub.example.com"));
         assert!(blocklist.is_blocked("deep.sub.example.com"));
@@ -174,7 +191,7 @@ mod tests {
         let mut domains = HashSet::new();
         domains.insert("example.com".to_string());
 
-        let blocklist = Blocklist::new(domains);
+        let blocklist = StaticBlocklist::new(domains);
 
         assert!(!blocklist.is_blocked("other.com"));
         assert!(!blocklist.is_blocked("example.org"));
@@ -194,7 +211,7 @@ mod tests {
             # google.com
         "#;
 
-        let blocklist = Blocklist::parse(content);
+        let blocklist = StaticBlocklist::parse(content);
 
         let expected = HashSet::from([
             "example.com".to_string(),

--- a/apps/dns-server/src/handler.rs
+++ b/apps/dns-server/src/handler.rs
@@ -6,7 +6,7 @@ use hickory_server::server::{Request, RequestHandler, ResponseHandler, ResponseI
 use hickory_server::zone_handler::MessageResponseBuilder;
 use opentelemetry::KeyValue;
 
-use crate::blocklist::BlocklistSource;
+use crate::blocklist::Blocklist;
 use crate::cache::ResponseCache;
 use crate::server::DnsServerMetrics;
 use crate::upstream::Upstream;
@@ -19,7 +19,7 @@ pub struct DnsRequestHandler<U, B> {
     metrics: DnsServerMetrics,
 }
 
-impl<U: Upstream, B: BlocklistSource> DnsRequestHandler<U, B> {
+impl<U: Upstream, B: Blocklist> DnsRequestHandler<U, B> {
     pub fn new(upstream: U, blocklist: B, cache: ResponseCache, metrics: DnsServerMetrics) -> Self {
         Self {
             upstream,
@@ -41,7 +41,7 @@ fn make_response_info(request: &Request) -> ResponseInfo {
 impl<U, B> RequestHandler for DnsRequestHandler<U, B>
 where
     U: Upstream + 'static,
-    B: BlocklistSource + 'static,
+    B: Blocklist + 'static,
 {
     async fn handle_request<R: ResponseHandler, T: Time>(
         &self,
@@ -235,7 +235,7 @@ mod tests {
     use hickory_server::server::{Request, RequestHandler, ResponseInfo};
     use hickory_server::zone_handler::MessageResponse;
 
-    use crate::blocklist::BlocklistSource;
+    use crate::blocklist::Blocklist;
     use crate::cache::ResponseCache;
     use crate::config::CacheConfig;
     use crate::server::DnsServerMetrics;
@@ -289,7 +289,7 @@ mod tests {
     struct AlwaysBlocked;
 
     #[async_trait::async_trait]
-    impl BlocklistSource for AlwaysBlocked {
+    impl Blocklist for AlwaysBlocked {
         async fn is_blocked(&self, _: &str) -> bool {
             true
         }
@@ -299,7 +299,7 @@ mod tests {
     struct NeverBlocked;
 
     #[async_trait::async_trait]
-    impl BlocklistSource for NeverBlocked {
+    impl Blocklist for NeverBlocked {
         async fn is_blocked(&self, _: &str) -> bool {
             false
         }

--- a/apps/dns-server/src/main.rs
+++ b/apps/dns-server/src/main.rs
@@ -1,3 +1,5 @@
+use std::time::Duration;
+
 use color_eyre::eyre::Result;
 use foundation_recurring_job::RecurringJob;
 use foundation_shutdown::ShutdownCoordinator;
@@ -10,7 +12,7 @@ mod handler;
 mod server;
 mod upstream;
 
-use crate::blocklist::BlocklistManager;
+use crate::blocklist::{BlocklistManager, ExternalBytesBlocklistResolver};
 use crate::cache::ResponseCache;
 use crate::config::Configuration;
 use crate::server::{DnsServer, DnsServerMetrics};
@@ -26,7 +28,10 @@ async fn main() -> Result<()> {
         "dns server initialized"
     );
 
-    let blocklist = BlocklistManager::new(config.blocklist.clone()).await?;
+    let interval = Duration::from_secs(config.blocklist.refresh_interval_seconds);
+    let resolver = ExternalBytesBlocklistResolver::new(config.blocklist.source.clone());
+
+    let blocklist = BlocklistManager::new(interval, resolver).await?;
     let upstream = UpstreamResolver::new(&config.upstream).await?;
     let cache = ResponseCache::new(&config.cache);
 


### PR DESCRIPTION
In the future, it would be useful to support multiple backends for the blocklist (such as using a database instead) so let's work on abstracting this concept out.

This change:
* Renames some types to make more sense
* Adds a `BlocklistResolver` and updates everything to use it
