### PR TITLE
feat: remove OpenRouter record

### DIFF
--- a/infrastructure/terraform/aws.tf
+++ b/infrastructure/terraform/aws.tf
@@ -400,7 +400,6 @@ resource "aws_route53_record" "records" {
     "events",
     "grafana",
     "lockers",
-    "or",
     "tags",
     "today",
     "uptime"


### PR DESCRIPTION
This is no longer needed as I've done the talk that required it, so let's start tearing down the infrastructure.

This change:
* Removes the DNS record
